### PR TITLE
Update aws_c_http_jll to version 0.9.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsHTTP"
 uuid = "ce851869-0d7a-41e7-95ef-2d4cb63876dd"
-version = "1.2.0"
+version = "1.2.1"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -17,7 +17,7 @@ LibAwsCal = "1.1"
 LibAwsCommon = "1.2"
 LibAwsCompression = "1.1"
 LibAwsIO = "1.2"
-aws_c_http_jll = "=0.8.4"
+aws_c_http_jll = "=0.9.5"
 julia = "1.6"
 
 [extras]

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -14,4 +14,4 @@ aws_c_io_jll = "13c41daa-f319-5298-b5eb-5754e0170d52"
 [compat]
 Clang = "0.18.3"
 JLLPrefixes = "0.3"
-aws_c_http_jll = "=0.8.4"
+aws_c_http_jll = "=0.9.5"

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -635,6 +635,7 @@ struct aws_http_connection_manager_options
     bootstrap::Ptr{aws_client_bootstrap}
     initial_window_size::Csize_t
     socket_options::Ptr{aws_socket_options}
+    response_first_byte_timeout_ms::UInt64
     tls_connection_options::Ptr{aws_tls_connection_options}
     http2_prior_knowledge::Bool
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
@@ -1197,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    __JL_Ctag_137
+    union (unnamed at /home/runner/.julia/artifacts/7614c5444fe2be11ee72c7a1744227ee3912c72c/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_137
+struct var"union (unnamed at /home/runner/.julia/artifacts/7614c5444fe2be11ee72c7a1744227ee3912c72c/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_137}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7614c5444fe2be11ee72c7a1744227ee3912c72c/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_137, f::Symbol)
-    r = Ref{__JL_Ctag_137}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_137}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/7614c5444fe2be11ee72c7a1744227ee3912c72c/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/7614c5444fe2be11ee72c7a1744227ee3912c72c/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7614c5444fe2be11ee72c7a1744227ee3912c72c/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_137}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7614c5444fe2be11ee72c7a1744227ee3912c72c/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1234,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{__JL_Ctag_137}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7614c5444fe2be11ee72c7a1744227ee3912c72c/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -1702,7 +1703,6 @@ Invoked when the data stream of an outgoing HTTP write operation is no longer in
 """
 const aws_http_stream_write_complete_fn = Cvoid
 
-# typedef aws_http_stream_write_complete_fn aws_http1_stream_write_chunk_complete_fn
 """
 Invoked when the data of an outgoing HTTP/1.1 chunk is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -1737,7 +1737,6 @@ struct aws_http1_chunk_options
     user_data::Ptr{Cvoid}
 end
 
-# typedef aws_http_stream_write_complete_fn aws_http2_stream_write_data_complete_fn
 """
 Invoked when the data of an outgoing HTTP2 data frame is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -2626,7 +2625,7 @@ end
 """
     aws_http1_stream_write_chunk(http1_stream, options)
 
-Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
+Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header, and the [`aws_http_message`](@ref) must NOT have any body stream set. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
 
 Returns AWS\\_OP\\_SUCCESS if the chunk has been submitted. The chunk's completion callback will be invoked when the HTTP-stream is done with the chunk data, whether or not it was successfully sent (see [`aws_http1_stream_write_chunk_complete_fn`](@ref)). The chunk data must remain valid until the completion callback is invoked.
 

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -635,6 +635,7 @@ struct aws_http_connection_manager_options
     bootstrap::Ptr{aws_client_bootstrap}
     initial_window_size::Csize_t
     socket_options::Ptr{aws_socket_options}
+    response_first_byte_timeout_ms::UInt64
     tls_connection_options::Ptr{aws_tls_connection_options}
     http2_prior_knowledge::Bool
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
@@ -1197,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    __JL_Ctag_371
+    union (unnamed at /home/runner/.julia/artifacts/cb2562b0c20a3137b66f577852b9b1dfccdd8a62/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_371
+struct var"union (unnamed at /home/runner/.julia/artifacts/cb2562b0c20a3137b66f577852b9b1dfccdd8a62/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_371}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cb2562b0c20a3137b66f577852b9b1dfccdd8a62/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_371, f::Symbol)
-    r = Ref{__JL_Ctag_371}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_371}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/cb2562b0c20a3137b66f577852b9b1dfccdd8a62/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/cb2562b0c20a3137b66f577852b9b1dfccdd8a62/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cb2562b0c20a3137b66f577852b9b1dfccdd8a62/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_371}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cb2562b0c20a3137b66f577852b9b1dfccdd8a62/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1234,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{__JL_Ctag_371}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cb2562b0c20a3137b66f577852b9b1dfccdd8a62/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -1702,7 +1703,6 @@ Invoked when the data stream of an outgoing HTTP write operation is no longer in
 """
 const aws_http_stream_write_complete_fn = Cvoid
 
-# typedef aws_http_stream_write_complete_fn aws_http1_stream_write_chunk_complete_fn
 """
 Invoked when the data of an outgoing HTTP/1.1 chunk is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -1737,7 +1737,6 @@ struct aws_http1_chunk_options
     user_data::Ptr{Cvoid}
 end
 
-# typedef aws_http_stream_write_complete_fn aws_http2_stream_write_data_complete_fn
 """
 Invoked when the data of an outgoing HTTP2 data frame is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -2626,7 +2625,7 @@ end
 """
     aws_http1_stream_write_chunk(http1_stream, options)
 
-Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
+Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header, and the [`aws_http_message`](@ref) must NOT have any body stream set. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
 
 Returns AWS\\_OP\\_SUCCESS if the chunk has been submitted. The chunk's completion callback will be invoked when the HTTP-stream is done with the chunk data, whether or not it was successfully sent (see [`aws_http1_stream_write_chunk_complete_fn`](@ref)). The chunk data must remain valid until the completion callback is invoked.
 

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -635,6 +635,7 @@ struct aws_http_connection_manager_options
     bootstrap::Ptr{aws_client_bootstrap}
     initial_window_size::Csize_t
     socket_options::Ptr{aws_socket_options}
+    response_first_byte_timeout_ms::UInt64
     tls_connection_options::Ptr{aws_tls_connection_options}
     http2_prior_knowledge::Bool
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
@@ -1197,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    __JL_Ctag_155
+    union (unnamed at /home/runner/.julia/artifacts/43b0caf1f22acd0df66c9633ea7f7e9d4e6a65ed/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_155
+struct var"union (unnamed at /home/runner/.julia/artifacts/43b0caf1f22acd0df66c9633ea7f7e9d4e6a65ed/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_155}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/43b0caf1f22acd0df66c9633ea7f7e9d4e6a65ed/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_155, f::Symbol)
-    r = Ref{__JL_Ctag_155}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_155}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/43b0caf1f22acd0df66c9633ea7f7e9d4e6a65ed/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/43b0caf1f22acd0df66c9633ea7f7e9d4e6a65ed/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/43b0caf1f22acd0df66c9633ea7f7e9d4e6a65ed/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_155}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/43b0caf1f22acd0df66c9633ea7f7e9d4e6a65ed/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1234,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{__JL_Ctag_155}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/43b0caf1f22acd0df66c9633ea7f7e9d4e6a65ed/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -1702,7 +1703,6 @@ Invoked when the data stream of an outgoing HTTP write operation is no longer in
 """
 const aws_http_stream_write_complete_fn = Cvoid
 
-# typedef aws_http_stream_write_complete_fn aws_http1_stream_write_chunk_complete_fn
 """
 Invoked when the data of an outgoing HTTP/1.1 chunk is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -1737,7 +1737,6 @@ struct aws_http1_chunk_options
     user_data::Ptr{Cvoid}
 end
 
-# typedef aws_http_stream_write_complete_fn aws_http2_stream_write_data_complete_fn
 """
 Invoked when the data of an outgoing HTTP2 data frame is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -2626,7 +2625,7 @@ end
 """
     aws_http1_stream_write_chunk(http1_stream, options)
 
-Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
+Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header, and the [`aws_http_message`](@ref) must NOT have any body stream set. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
 
 Returns AWS\\_OP\\_SUCCESS if the chunk has been submitted. The chunk's completion callback will be invoked when the HTTP-stream is done with the chunk data, whether or not it was successfully sent (see [`aws_http1_stream_write_chunk_complete_fn`](@ref)). The chunk data must remain valid until the completion callback is invoked.
 

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -635,6 +635,7 @@ struct aws_http_connection_manager_options
     bootstrap::Ptr{aws_client_bootstrap}
     initial_window_size::Csize_t
     socket_options::Ptr{aws_socket_options}
+    response_first_byte_timeout_ms::UInt64
     tls_connection_options::Ptr{aws_tls_connection_options}
     http2_prior_knowledge::Bool
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
@@ -1197,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    __JL_Ctag_371
+    union (unnamed at /home/runner/.julia/artifacts/fda30967ffb6c32180307c041a2d27c3311dbc9e/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_371
+struct var"union (unnamed at /home/runner/.julia/artifacts/fda30967ffb6c32180307c041a2d27c3311dbc9e/include/aws/http/proxy.h:302:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_371}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fda30967ffb6c32180307c041a2d27c3311dbc9e/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_371, f::Symbol)
-    r = Ref{__JL_Ctag_371}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_371}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/fda30967ffb6c32180307c041a2d27c3311dbc9e/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/fda30967ffb6c32180307c041a2d27c3311dbc9e/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fda30967ffb6c32180307c041a2d27c3311dbc9e/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_371}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fda30967ffb6c32180307c041a2d27c3311dbc9e/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1234,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{__JL_Ctag_371}(x + 16)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fda30967ffb6c32180307c041a2d27c3311dbc9e/include/aws/http/proxy.h:302:5)"}(x + 16)
     return getfield(x, f)
 end
 
@@ -1702,7 +1703,6 @@ Invoked when the data stream of an outgoing HTTP write operation is no longer in
 """
 const aws_http_stream_write_complete_fn = Cvoid
 
-# typedef aws_http_stream_write_complete_fn aws_http1_stream_write_chunk_complete_fn
 """
 Invoked when the data of an outgoing HTTP/1.1 chunk is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -1737,7 +1737,6 @@ struct aws_http1_chunk_options
     user_data::Ptr{Cvoid}
 end
 
-# typedef aws_http_stream_write_complete_fn aws_http2_stream_write_data_complete_fn
 """
 Invoked when the data of an outgoing HTTP2 data frame is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -2626,7 +2625,7 @@ end
 """
     aws_http1_stream_write_chunk(http1_stream, options)
 
-Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
+Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header, and the [`aws_http_message`](@ref) must NOT have any body stream set. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
 
 Returns AWS\\_OP\\_SUCCESS if the chunk has been submitted. The chunk's completion callback will be invoked when the HTTP-stream is done with the chunk data, whether or not it was successfully sent (see [`aws_http1_stream_write_chunk_complete_fn`](@ref)). The chunk data must remain valid until the completion callback is invoked.
 

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -635,6 +635,7 @@ struct aws_http_connection_manager_options
     bootstrap::Ptr{aws_client_bootstrap}
     initial_window_size::Csize_t
     socket_options::Ptr{aws_socket_options}
+    response_first_byte_timeout_ms::UInt64
     tls_connection_options::Ptr{aws_tls_connection_options}
     http2_prior_knowledge::Bool
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
@@ -1197,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    __JL_Ctag_155
+    union (unnamed at /home/runner/.julia/artifacts/ac96d6f140faea6fe4bd7459c6e30542f478e3fa/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_155
+struct var"union (unnamed at /home/runner/.julia/artifacts/ac96d6f140faea6fe4bd7459c6e30542f478e3fa/include/aws/http/proxy.h:302:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_155}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ac96d6f140faea6fe4bd7459c6e30542f478e3fa/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_155, f::Symbol)
-    r = Ref{__JL_Ctag_155}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_155}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/ac96d6f140faea6fe4bd7459c6e30542f478e3fa/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/ac96d6f140faea6fe4bd7459c6e30542f478e3fa/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ac96d6f140faea6fe4bd7459c6e30542f478e3fa/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_155}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ac96d6f140faea6fe4bd7459c6e30542f478e3fa/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1234,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{__JL_Ctag_155}(x + 16)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ac96d6f140faea6fe4bd7459c6e30542f478e3fa/include/aws/http/proxy.h:302:5)"}(x + 16)
     return getfield(x, f)
 end
 
@@ -1702,7 +1703,6 @@ Invoked when the data stream of an outgoing HTTP write operation is no longer in
 """
 const aws_http_stream_write_complete_fn = Cvoid
 
-# typedef aws_http_stream_write_complete_fn aws_http1_stream_write_chunk_complete_fn
 """
 Invoked when the data of an outgoing HTTP/1.1 chunk is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -1737,7 +1737,6 @@ struct aws_http1_chunk_options
     user_data::Ptr{Cvoid}
 end
 
-# typedef aws_http_stream_write_complete_fn aws_http2_stream_write_data_complete_fn
 """
 Invoked when the data of an outgoing HTTP2 data frame is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -2626,7 +2625,7 @@ end
 """
     aws_http1_stream_write_chunk(http1_stream, options)
 
-Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
+Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header, and the [`aws_http_message`](@ref) must NOT have any body stream set. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
 
 Returns AWS\\_OP\\_SUCCESS if the chunk has been submitted. The chunk's completion callback will be invoked when the HTTP-stream is done with the chunk data, whether or not it was successfully sent (see [`aws_http1_stream_write_chunk_complete_fn`](@ref)). The chunk data must remain valid until the completion callback is invoked.
 

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -635,6 +635,7 @@ struct aws_http_connection_manager_options
     bootstrap::Ptr{aws_client_bootstrap}
     initial_window_size::Csize_t
     socket_options::Ptr{aws_socket_options}
+    response_first_byte_timeout_ms::UInt64
     tls_connection_options::Ptr{aws_tls_connection_options}
     http2_prior_knowledge::Bool
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
@@ -1197,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    __JL_Ctag_362
+    union (unnamed at /home/runner/.julia/artifacts/c765b23ffc909467a014fac270425a7f0b0cd104/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_362
+struct var"union (unnamed at /home/runner/.julia/artifacts/c765b23ffc909467a014fac270425a7f0b0cd104/include/aws/http/proxy.h:302:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_362}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c765b23ffc909467a014fac270425a7f0b0cd104/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_362, f::Symbol)
-    r = Ref{__JL_Ctag_362}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_362}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/c765b23ffc909467a014fac270425a7f0b0cd104/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/c765b23ffc909467a014fac270425a7f0b0cd104/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c765b23ffc909467a014fac270425a7f0b0cd104/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_362}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c765b23ffc909467a014fac270425a7f0b0cd104/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1234,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{__JL_Ctag_362}(x + 16)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c765b23ffc909467a014fac270425a7f0b0cd104/include/aws/http/proxy.h:302:5)"}(x + 16)
     return getfield(x, f)
 end
 
@@ -1702,7 +1703,6 @@ Invoked when the data stream of an outgoing HTTP write operation is no longer in
 """
 const aws_http_stream_write_complete_fn = Cvoid
 
-# typedef aws_http_stream_write_complete_fn aws_http1_stream_write_chunk_complete_fn
 """
 Invoked when the data of an outgoing HTTP/1.1 chunk is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -1737,7 +1737,6 @@ struct aws_http1_chunk_options
     user_data::Ptr{Cvoid}
 end
 
-# typedef aws_http_stream_write_complete_fn aws_http2_stream_write_data_complete_fn
 """
 Invoked when the data of an outgoing HTTP2 data frame is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -2626,7 +2625,7 @@ end
 """
     aws_http1_stream_write_chunk(http1_stream, options)
 
-Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
+Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header, and the [`aws_http_message`](@ref) must NOT have any body stream set. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
 
 Returns AWS\\_OP\\_SUCCESS if the chunk has been submitted. The chunk's completion callback will be invoked when the HTTP-stream is done with the chunk data, whether or not it was successfully sent (see [`aws_http1_stream_write_chunk_complete_fn`](@ref)). The chunk data must remain valid until the completion callback is invoked.
 

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -635,6 +635,7 @@ struct aws_http_connection_manager_options
     bootstrap::Ptr{aws_client_bootstrap}
     initial_window_size::Csize_t
     socket_options::Ptr{aws_socket_options}
+    response_first_byte_timeout_ms::UInt64
     tls_connection_options::Ptr{aws_tls_connection_options}
     http2_prior_knowledge::Bool
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
@@ -1197,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    __JL_Ctag_155
+    union (unnamed at /home/runner/.julia/artifacts/8f473bb25df60d899a8c63ee42add6b7dbd02e8e/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_155
+struct var"union (unnamed at /home/runner/.julia/artifacts/8f473bb25df60d899a8c63ee42add6b7dbd02e8e/include/aws/http/proxy.h:302:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_155}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8f473bb25df60d899a8c63ee42add6b7dbd02e8e/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_155, f::Symbol)
-    r = Ref{__JL_Ctag_155}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_155}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/8f473bb25df60d899a8c63ee42add6b7dbd02e8e/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/8f473bb25df60d899a8c63ee42add6b7dbd02e8e/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8f473bb25df60d899a8c63ee42add6b7dbd02e8e/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_155}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8f473bb25df60d899a8c63ee42add6b7dbd02e8e/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1234,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{__JL_Ctag_155}(x + 16)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8f473bb25df60d899a8c63ee42add6b7dbd02e8e/include/aws/http/proxy.h:302:5)"}(x + 16)
     return getfield(x, f)
 end
 
@@ -1702,7 +1703,6 @@ Invoked when the data stream of an outgoing HTTP write operation is no longer in
 """
 const aws_http_stream_write_complete_fn = Cvoid
 
-# typedef aws_http_stream_write_complete_fn aws_http1_stream_write_chunk_complete_fn
 """
 Invoked when the data of an outgoing HTTP/1.1 chunk is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -1737,7 +1737,6 @@ struct aws_http1_chunk_options
     user_data::Ptr{Cvoid}
 end
 
-# typedef aws_http_stream_write_complete_fn aws_http2_stream_write_data_complete_fn
 """
 Invoked when the data of an outgoing HTTP2 data frame is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -2626,7 +2625,7 @@ end
 """
     aws_http1_stream_write_chunk(http1_stream, options)
 
-Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
+Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header, and the [`aws_http_message`](@ref) must NOT have any body stream set. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
 
 Returns AWS\\_OP\\_SUCCESS if the chunk has been submitted. The chunk's completion callback will be invoked when the HTTP-stream is done with the chunk data, whether or not it was successfully sent (see [`aws_http1_stream_write_chunk_complete_fn`](@ref)). The chunk data must remain valid until the completion callback is invoked.
 

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -635,6 +635,7 @@ struct aws_http_connection_manager_options
     bootstrap::Ptr{aws_client_bootstrap}
     initial_window_size::Csize_t
     socket_options::Ptr{aws_socket_options}
+    response_first_byte_timeout_ms::UInt64
     tls_connection_options::Ptr{aws_tls_connection_options}
     http2_prior_knowledge::Bool
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
@@ -1197,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    __JL_Ctag_362
+    union (unnamed at /home/runner/.julia/artifacts/b1574662f8895687b1b176bdf808c67e03bdacbf/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_362
+struct var"union (unnamed at /home/runner/.julia/artifacts/b1574662f8895687b1b176bdf808c67e03bdacbf/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_362}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b1574662f8895687b1b176bdf808c67e03bdacbf/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_362, f::Symbol)
-    r = Ref{__JL_Ctag_362}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_362}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/b1574662f8895687b1b176bdf808c67e03bdacbf/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/b1574662f8895687b1b176bdf808c67e03bdacbf/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b1574662f8895687b1b176bdf808c67e03bdacbf/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_362}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b1574662f8895687b1b176bdf808c67e03bdacbf/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1234,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{__JL_Ctag_362}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b1574662f8895687b1b176bdf808c67e03bdacbf/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -1702,7 +1703,6 @@ Invoked when the data stream of an outgoing HTTP write operation is no longer in
 """
 const aws_http_stream_write_complete_fn = Cvoid
 
-# typedef aws_http_stream_write_complete_fn aws_http1_stream_write_chunk_complete_fn
 """
 Invoked when the data of an outgoing HTTP/1.1 chunk is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -1737,7 +1737,6 @@ struct aws_http1_chunk_options
     user_data::Ptr{Cvoid}
 end
 
-# typedef aws_http_stream_write_complete_fn aws_http2_stream_write_data_complete_fn
 """
 Invoked when the data of an outgoing HTTP2 data frame is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -2626,7 +2625,7 @@ end
 """
     aws_http1_stream_write_chunk(http1_stream, options)
 
-Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
+Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header, and the [`aws_http_message`](@ref) must NOT have any body stream set. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
 
 Returns AWS\\_OP\\_SUCCESS if the chunk has been submitted. The chunk's completion callback will be invoked when the HTTP-stream is done with the chunk data, whether or not it was successfully sent (see [`aws_http1_stream_write_chunk_complete_fn`](@ref)). The chunk data must remain valid until the completion callback is invoked.
 

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -635,6 +635,7 @@ struct aws_http_connection_manager_options
     bootstrap::Ptr{aws_client_bootstrap}
     initial_window_size::Csize_t
     socket_options::Ptr{aws_socket_options}
+    response_first_byte_timeout_ms::UInt64
     tls_connection_options::Ptr{aws_tls_connection_options}
     http2_prior_knowledge::Bool
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
@@ -1197,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    __JL_Ctag_137
+    union (unnamed at /home/runner/.julia/artifacts/5ac6901790ff1a6eefd7ac2121ebb945090fa6b3/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_137
+struct var"union (unnamed at /home/runner/.julia/artifacts/5ac6901790ff1a6eefd7ac2121ebb945090fa6b3/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_137}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5ac6901790ff1a6eefd7ac2121ebb945090fa6b3/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_137, f::Symbol)
-    r = Ref{__JL_Ctag_137}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_137}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/5ac6901790ff1a6eefd7ac2121ebb945090fa6b3/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/5ac6901790ff1a6eefd7ac2121ebb945090fa6b3/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5ac6901790ff1a6eefd7ac2121ebb945090fa6b3/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_137}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5ac6901790ff1a6eefd7ac2121ebb945090fa6b3/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1234,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{__JL_Ctag_137}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5ac6901790ff1a6eefd7ac2121ebb945090fa6b3/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -1702,7 +1703,6 @@ Invoked when the data stream of an outgoing HTTP write operation is no longer in
 """
 const aws_http_stream_write_complete_fn = Cvoid
 
-# typedef aws_http_stream_write_complete_fn aws_http1_stream_write_chunk_complete_fn
 """
 Invoked when the data of an outgoing HTTP/1.1 chunk is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -1737,7 +1737,6 @@ struct aws_http1_chunk_options
     user_data::Ptr{Cvoid}
 end
 
-# typedef aws_http_stream_write_complete_fn aws_http2_stream_write_data_complete_fn
 """
 Invoked when the data of an outgoing HTTP2 data frame is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -2626,7 +2625,7 @@ end
 """
     aws_http1_stream_write_chunk(http1_stream, options)
 
-Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
+Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header, and the [`aws_http_message`](@ref) must NOT have any body stream set. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
 
 Returns AWS\\_OP\\_SUCCESS if the chunk has been submitted. The chunk's completion callback will be invoked when the HTTP-stream is done with the chunk data, whether or not it was successfully sent (see [`aws_http1_stream_write_chunk_complete_fn`](@ref)). The chunk data must remain valid until the completion callback is invoked.
 

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -635,6 +635,7 @@ struct aws_http_connection_manager_options
     bootstrap::Ptr{aws_client_bootstrap}
     initial_window_size::Csize_t
     socket_options::Ptr{aws_socket_options}
+    response_first_byte_timeout_ms::UInt64
     tls_connection_options::Ptr{aws_tls_connection_options}
     http2_prior_knowledge::Bool
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
@@ -1197,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    __JL_Ctag_362
+    union (unnamed at /home/runner/.julia/artifacts/85685389a7cf65da8cc0602c40154726f3d3d455/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_362
+struct var"union (unnamed at /home/runner/.julia/artifacts/85685389a7cf65da8cc0602c40154726f3d3d455/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_362}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/85685389a7cf65da8cc0602c40154726f3d3d455/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_362, f::Symbol)
-    r = Ref{__JL_Ctag_362}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_362}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/85685389a7cf65da8cc0602c40154726f3d3d455/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/85685389a7cf65da8cc0602c40154726f3d3d455/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/85685389a7cf65da8cc0602c40154726f3d3d455/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_362}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/85685389a7cf65da8cc0602c40154726f3d3d455/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1234,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{__JL_Ctag_362}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/85685389a7cf65da8cc0602c40154726f3d3d455/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -1702,7 +1703,6 @@ Invoked when the data stream of an outgoing HTTP write operation is no longer in
 """
 const aws_http_stream_write_complete_fn = Cvoid
 
-# typedef aws_http_stream_write_complete_fn aws_http1_stream_write_chunk_complete_fn
 """
 Invoked when the data of an outgoing HTTP/1.1 chunk is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -1737,7 +1737,6 @@ struct aws_http1_chunk_options
     user_data::Ptr{Cvoid}
 end
 
-# typedef aws_http_stream_write_complete_fn aws_http2_stream_write_data_complete_fn
 """
 Invoked when the data of an outgoing HTTP2 data frame is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -2626,7 +2625,7 @@ end
 """
     aws_http1_stream_write_chunk(http1_stream, options)
 
-Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
+Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header, and the [`aws_http_message`](@ref) must NOT have any body stream set. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
 
 Returns AWS\\_OP\\_SUCCESS if the chunk has been submitted. The chunk's completion callback will be invoked when the HTTP-stream is done with the chunk data, whether or not it was successfully sent (see [`aws_http1_stream_write_chunk_complete_fn`](@ref)). The chunk data must remain valid until the completion callback is invoked.
 

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -635,6 +635,7 @@ struct aws_http_connection_manager_options
     bootstrap::Ptr{aws_client_bootstrap}
     initial_window_size::Csize_t
     socket_options::Ptr{aws_socket_options}
+    response_first_byte_timeout_ms::UInt64
     tls_connection_options::Ptr{aws_tls_connection_options}
     http2_prior_knowledge::Bool
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
@@ -1197,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    __JL_Ctag_155
+    union (unnamed at /home/runner/.julia/artifacts/e1d523ec4a898136794a60e8b2b532cd445969b8/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_155
+struct var"union (unnamed at /home/runner/.julia/artifacts/e1d523ec4a898136794a60e8b2b532cd445969b8/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_155}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e1d523ec4a898136794a60e8b2b532cd445969b8/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_155, f::Symbol)
-    r = Ref{__JL_Ctag_155}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_155}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/e1d523ec4a898136794a60e8b2b532cd445969b8/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/e1d523ec4a898136794a60e8b2b532cd445969b8/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e1d523ec4a898136794a60e8b2b532cd445969b8/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_155}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e1d523ec4a898136794a60e8b2b532cd445969b8/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1234,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{__JL_Ctag_155}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e1d523ec4a898136794a60e8b2b532cd445969b8/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -1702,7 +1703,6 @@ Invoked when the data stream of an outgoing HTTP write operation is no longer in
 """
 const aws_http_stream_write_complete_fn = Cvoid
 
-# typedef aws_http_stream_write_complete_fn aws_http1_stream_write_chunk_complete_fn
 """
 Invoked when the data of an outgoing HTTP/1.1 chunk is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -1737,7 +1737,6 @@ struct aws_http1_chunk_options
     user_data::Ptr{Cvoid}
 end
 
-# typedef aws_http_stream_write_complete_fn aws_http2_stream_write_data_complete_fn
 """
 Invoked when the data of an outgoing HTTP2 data frame is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -2626,7 +2625,7 @@ end
 """
     aws_http1_stream_write_chunk(http1_stream, options)
 
-Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
+Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header, and the [`aws_http_message`](@ref) must NOT have any body stream set. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
 
 Returns AWS\\_OP\\_SUCCESS if the chunk has been submitted. The chunk's completion callback will be invoked when the HTTP-stream is done with the chunk data, whether or not it was successfully sent (see [`aws_http1_stream_write_chunk_complete_fn`](@ref)). The chunk data must remain valid until the completion callback is invoked.
 

--- a/lib/x86_64-unknown-freebsd13.2.jl
+++ b/lib/x86_64-unknown-freebsd13.2.jl
@@ -635,6 +635,7 @@ struct aws_http_connection_manager_options
     bootstrap::Ptr{aws_client_bootstrap}
     initial_window_size::Csize_t
     socket_options::Ptr{aws_socket_options}
+    response_first_byte_timeout_ms::UInt64
     tls_connection_options::Ptr{aws_tls_connection_options}
     http2_prior_knowledge::Bool
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
@@ -1197,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    __JL_Ctag_119
+    union (unnamed at /home/runner/.julia/artifacts/1c6926758aef4bb8c82444fa63324186602b7346/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_119
+struct var"union (unnamed at /home/runner/.julia/artifacts/1c6926758aef4bb8c82444fa63324186602b7346/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_119}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1c6926758aef4bb8c82444fa63324186602b7346/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_119, f::Symbol)
-    r = Ref{__JL_Ctag_119}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_119}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/1c6926758aef4bb8c82444fa63324186602b7346/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/1c6926758aef4bb8c82444fa63324186602b7346/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1c6926758aef4bb8c82444fa63324186602b7346/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_119}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1c6926758aef4bb8c82444fa63324186602b7346/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1234,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{__JL_Ctag_119}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1c6926758aef4bb8c82444fa63324186602b7346/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -1702,7 +1703,6 @@ Invoked when the data stream of an outgoing HTTP write operation is no longer in
 """
 const aws_http_stream_write_complete_fn = Cvoid
 
-# typedef aws_http_stream_write_complete_fn aws_http1_stream_write_chunk_complete_fn
 """
 Invoked when the data of an outgoing HTTP/1.1 chunk is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -1737,7 +1737,6 @@ struct aws_http1_chunk_options
     user_data::Ptr{Cvoid}
 end
 
-# typedef aws_http_stream_write_complete_fn aws_http2_stream_write_data_complete_fn
 """
 Invoked when the data of an outgoing HTTP2 data frame is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -2626,7 +2625,7 @@ end
 """
     aws_http1_stream_write_chunk(http1_stream, options)
 
-Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
+Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header, and the [`aws_http_message`](@ref) must NOT have any body stream set. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
 
 Returns AWS\\_OP\\_SUCCESS if the chunk has been submitted. The chunk's completion callback will be invoked when the HTTP-stream is done with the chunk data, whether or not it was successfully sent (see [`aws_http1_stream_write_chunk_complete_fn`](@ref)). The chunk data must remain valid until the completion callback is invoked.
 

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -635,6 +635,7 @@ struct aws_http_connection_manager_options
     bootstrap::Ptr{aws_client_bootstrap}
     initial_window_size::Csize_t
     socket_options::Ptr{aws_socket_options}
+    response_first_byte_timeout_ms::UInt64
     tls_connection_options::Ptr{aws_tls_connection_options}
     http2_prior_knowledge::Bool
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
@@ -1197,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    __JL_Ctag_101
+    union (unnamed at /home/runner/.julia/artifacts/0632eb331c30b7b3fde654b04b7df07c8e7edf30/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_101
+struct var"union (unnamed at /home/runner/.julia/artifacts/0632eb331c30b7b3fde654b04b7df07c8e7edf30/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_101}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0632eb331c30b7b3fde654b04b7df07c8e7edf30/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_101, f::Symbol)
-    r = Ref{__JL_Ctag_101}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_101}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/0632eb331c30b7b3fde654b04b7df07c8e7edf30/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/0632eb331c30b7b3fde654b04b7df07c8e7edf30/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0632eb331c30b7b3fde654b04b7df07c8e7edf30/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_101}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0632eb331c30b7b3fde654b04b7df07c8e7edf30/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1234,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{__JL_Ctag_101}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0632eb331c30b7b3fde654b04b7df07c8e7edf30/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -1702,7 +1703,6 @@ Invoked when the data stream of an outgoing HTTP write operation is no longer in
 """
 const aws_http_stream_write_complete_fn = Cvoid
 
-# typedef aws_http_stream_write_complete_fn aws_http1_stream_write_chunk_complete_fn
 """
 Invoked when the data of an outgoing HTTP/1.1 chunk is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -1737,7 +1737,6 @@ struct aws_http1_chunk_options
     user_data::Ptr{Cvoid}
 end
 
-# typedef aws_http_stream_write_complete_fn aws_http2_stream_write_data_complete_fn
 """
 Invoked when the data of an outgoing HTTP2 data frame is no longer in use. This is always invoked on the HTTP connection's event-loop thread.
 
@@ -2626,7 +2625,7 @@ end
 """
     aws_http1_stream_write_chunk(http1_stream, options)
 
-Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
+Submit a chunk of data to be sent on an HTTP/1.1 stream. The stream must have specified "chunked" in a "transfer-encoding" header, and the [`aws_http_message`](@ref) must NOT have any body stream set. For client streams, activate() must be called before any chunks are submitted. For server streams, the response must be submitted before any chunks. A final chunk with size 0 must be submitted to successfully complete the HTTP-stream.
 
 Returns AWS\\_OP\\_SUCCESS if the chunk has been submitted. The chunk's completion callback will be invoked when the HTTP-stream is done with the chunk data, whether or not it was successfully sent (see [`aws_http1_stream_write_chunk_complete_fn`](@ref)). The chunk data must remain valid until the completion callback is invoked.
 


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_http_jll** to version **0.9.5**
- Updated **JuliaServices/LibAwsHTTP.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings