### PR TITLE
Update aws_c_http_jll to version 0.9.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsHTTP"
 uuid = "ce851869-0d7a-41e7-95ef-2d4cb63876dd"
-version = "1.2.2"
+version = "1.2.3"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -17,7 +17,7 @@ LibAwsCal = "1.1"
 LibAwsCommon = "1.2"
 LibAwsCompression = "1.1"
 LibAwsIO = "1.2"
-aws_c_http_jll = "=0.9.6"
+aws_c_http_jll = "=0.9.7"
 julia = "1.6"
 
 [extras]

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -14,4 +14,4 @@ aws_c_io_jll = "13c41daa-f319-5298-b5eb-5754e0170d52"
 [compat]
 Clang = "0.18.3"
 JLLPrefixes = "0.3"
-aws_c_http_jll = "=0.9.6"
+aws_c_http_jll = "=0.9.7"

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -1198,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/24299fa4dd811165f243622bf0baaeb9755b7357/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/ed9521372c18e62eb942333df78a3ec2b873df95/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/24299fa4dd811165f243622bf0baaeb9755b7357/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/ed9521372c18e62eb942333df78a3ec2b873df95/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/24299fa4dd811165f243622bf0baaeb9755b7357/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ed9521372c18e62eb942333df78a3ec2b873df95/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/24299fa4dd811165f243622bf0baaeb9755b7357/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/24299fa4dd811165f243622bf0baaeb9755b7357/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/24299fa4dd811165f243622bf0baaeb9755b7357/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/ed9521372c18e62eb942333df78a3ec2b873df95/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/ed9521372c18e62eb942333df78a3ec2b873df95/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ed9521372c18e62eb942333df78a3ec2b873df95/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/24299fa4dd811165f243622bf0baaeb9755b7357/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ed9521372c18e62eb942333df78a3ec2b873df95/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/24299fa4dd811165f243622bf0baaeb9755b7357/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ed9521372c18e62eb942333df78a3ec2b873df95/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -1198,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/6afda93e296d3a58174a4822ad9a397a2a52c314/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/9ff8e5d46f663732c78d562a9684e8a7d066ee81/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/6afda93e296d3a58174a4822ad9a397a2a52c314/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/9ff8e5d46f663732c78d562a9684e8a7d066ee81/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6afda93e296d3a58174a4822ad9a397a2a52c314/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9ff8e5d46f663732c78d562a9684e8a7d066ee81/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/6afda93e296d3a58174a4822ad9a397a2a52c314/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/6afda93e296d3a58174a4822ad9a397a2a52c314/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6afda93e296d3a58174a4822ad9a397a2a52c314/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/9ff8e5d46f663732c78d562a9684e8a7d066ee81/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/9ff8e5d46f663732c78d562a9684e8a7d066ee81/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9ff8e5d46f663732c78d562a9684e8a7d066ee81/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6afda93e296d3a58174a4822ad9a397a2a52c314/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9ff8e5d46f663732c78d562a9684e8a7d066ee81/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6afda93e296d3a58174a4822ad9a397a2a52c314/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9ff8e5d46f663732c78d562a9684e8a7d066ee81/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -1198,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/3da49b84e93c9c3091807fb80e945da582a12d17/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/202b5e198dac9cd69d392ca209eab188e1acea6a/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/3da49b84e93c9c3091807fb80e945da582a12d17/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/202b5e198dac9cd69d392ca209eab188e1acea6a/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3da49b84e93c9c3091807fb80e945da582a12d17/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/202b5e198dac9cd69d392ca209eab188e1acea6a/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/3da49b84e93c9c3091807fb80e945da582a12d17/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/3da49b84e93c9c3091807fb80e945da582a12d17/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3da49b84e93c9c3091807fb80e945da582a12d17/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/202b5e198dac9cd69d392ca209eab188e1acea6a/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/202b5e198dac9cd69d392ca209eab188e1acea6a/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/202b5e198dac9cd69d392ca209eab188e1acea6a/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3da49b84e93c9c3091807fb80e945da582a12d17/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/202b5e198dac9cd69d392ca209eab188e1acea6a/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3da49b84e93c9c3091807fb80e945da582a12d17/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/202b5e198dac9cd69d392ca209eab188e1acea6a/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -1198,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/71f78b938a3430e2bb1c4716e492a2185bb0b9a5/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/9769d2ab3d6dc8486503e7070c42ca12d4509a75/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/71f78b938a3430e2bb1c4716e492a2185bb0b9a5/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/9769d2ab3d6dc8486503e7070c42ca12d4509a75/include/aws/http/proxy.h:302:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/71f78b938a3430e2bb1c4716e492a2185bb0b9a5/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9769d2ab3d6dc8486503e7070c42ca12d4509a75/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/71f78b938a3430e2bb1c4716e492a2185bb0b9a5/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/71f78b938a3430e2bb1c4716e492a2185bb0b9a5/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/71f78b938a3430e2bb1c4716e492a2185bb0b9a5/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/9769d2ab3d6dc8486503e7070c42ca12d4509a75/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/9769d2ab3d6dc8486503e7070c42ca12d4509a75/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9769d2ab3d6dc8486503e7070c42ca12d4509a75/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/71f78b938a3430e2bb1c4716e492a2185bb0b9a5/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9769d2ab3d6dc8486503e7070c42ca12d4509a75/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/71f78b938a3430e2bb1c4716e492a2185bb0b9a5/include/aws/http/proxy.h:302:5)"}(x + 16)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9769d2ab3d6dc8486503e7070c42ca12d4509a75/include/aws/http/proxy.h:302:5)"}(x + 16)
     return getfield(x, f)
 end
 

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -1198,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/f46be034ccbc76078ab03da168cc600c07e4a958/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/5f7d3b85932daaf94a4f435c280c0f94f6beaa11/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/f46be034ccbc76078ab03da168cc600c07e4a958/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/5f7d3b85932daaf94a4f435c280c0f94f6beaa11/include/aws/http/proxy.h:302:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f46be034ccbc76078ab03da168cc600c07e4a958/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5f7d3b85932daaf94a4f435c280c0f94f6beaa11/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/f46be034ccbc76078ab03da168cc600c07e4a958/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/f46be034ccbc76078ab03da168cc600c07e4a958/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f46be034ccbc76078ab03da168cc600c07e4a958/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/5f7d3b85932daaf94a4f435c280c0f94f6beaa11/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/5f7d3b85932daaf94a4f435c280c0f94f6beaa11/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5f7d3b85932daaf94a4f435c280c0f94f6beaa11/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f46be034ccbc76078ab03da168cc600c07e4a958/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5f7d3b85932daaf94a4f435c280c0f94f6beaa11/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f46be034ccbc76078ab03da168cc600c07e4a958/include/aws/http/proxy.h:302:5)"}(x + 16)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5f7d3b85932daaf94a4f435c280c0f94f6beaa11/include/aws/http/proxy.h:302:5)"}(x + 16)
     return getfield(x, f)
 end
 

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -1198,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/9f9b07424e59b97ce9b043e3a8dd09d094d5de5d/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/4bde5be8cca585e18ad5dde33f53c648861cf8d8/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/9f9b07424e59b97ce9b043e3a8dd09d094d5de5d/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/4bde5be8cca585e18ad5dde33f53c648861cf8d8/include/aws/http/proxy.h:302:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9f9b07424e59b97ce9b043e3a8dd09d094d5de5d/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4bde5be8cca585e18ad5dde33f53c648861cf8d8/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/9f9b07424e59b97ce9b043e3a8dd09d094d5de5d/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/9f9b07424e59b97ce9b043e3a8dd09d094d5de5d/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9f9b07424e59b97ce9b043e3a8dd09d094d5de5d/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/4bde5be8cca585e18ad5dde33f53c648861cf8d8/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/4bde5be8cca585e18ad5dde33f53c648861cf8d8/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4bde5be8cca585e18ad5dde33f53c648861cf8d8/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9f9b07424e59b97ce9b043e3a8dd09d094d5de5d/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4bde5be8cca585e18ad5dde33f53c648861cf8d8/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9f9b07424e59b97ce9b043e3a8dd09d094d5de5d/include/aws/http/proxy.h:302:5)"}(x + 16)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4bde5be8cca585e18ad5dde33f53c648861cf8d8/include/aws/http/proxy.h:302:5)"}(x + 16)
     return getfield(x, f)
 end
 

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -1198,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/6e445161829569e84af741d02155009eee5c0956/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/53696acfca00170545e4e289259e14c710b9076c/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/6e445161829569e84af741d02155009eee5c0956/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/53696acfca00170545e4e289259e14c710b9076c/include/aws/http/proxy.h:302:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6e445161829569e84af741d02155009eee5c0956/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/53696acfca00170545e4e289259e14c710b9076c/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/6e445161829569e84af741d02155009eee5c0956/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/6e445161829569e84af741d02155009eee5c0956/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6e445161829569e84af741d02155009eee5c0956/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/53696acfca00170545e4e289259e14c710b9076c/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/53696acfca00170545e4e289259e14c710b9076c/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/53696acfca00170545e4e289259e14c710b9076c/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6e445161829569e84af741d02155009eee5c0956/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/53696acfca00170545e4e289259e14c710b9076c/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6e445161829569e84af741d02155009eee5c0956/include/aws/http/proxy.h:302:5)"}(x + 16)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/53696acfca00170545e4e289259e14c710b9076c/include/aws/http/proxy.h:302:5)"}(x + 16)
     return getfield(x, f)
 end
 

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -1198,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/3d83d21f4a349aa6846ef6d0d4a546c984609367/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/8f2f0c33139094fbda3205c022c40f654ee21dc4/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/3d83d21f4a349aa6846ef6d0d4a546c984609367/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/8f2f0c33139094fbda3205c022c40f654ee21dc4/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3d83d21f4a349aa6846ef6d0d4a546c984609367/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8f2f0c33139094fbda3205c022c40f654ee21dc4/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/3d83d21f4a349aa6846ef6d0d4a546c984609367/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/3d83d21f4a349aa6846ef6d0d4a546c984609367/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3d83d21f4a349aa6846ef6d0d4a546c984609367/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/8f2f0c33139094fbda3205c022c40f654ee21dc4/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/8f2f0c33139094fbda3205c022c40f654ee21dc4/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8f2f0c33139094fbda3205c022c40f654ee21dc4/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3d83d21f4a349aa6846ef6d0d4a546c984609367/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8f2f0c33139094fbda3205c022c40f654ee21dc4/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3d83d21f4a349aa6846ef6d0d4a546c984609367/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8f2f0c33139094fbda3205c022c40f654ee21dc4/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -1198,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/d76d554dba67fbbdef6070ca6439f50150fc411b/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/05c9fae5d8a1a3fd0d6a6e48ecc28d50d0e1bf18/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/d76d554dba67fbbdef6070ca6439f50150fc411b/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/05c9fae5d8a1a3fd0d6a6e48ecc28d50d0e1bf18/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d76d554dba67fbbdef6070ca6439f50150fc411b/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/05c9fae5d8a1a3fd0d6a6e48ecc28d50d0e1bf18/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/d76d554dba67fbbdef6070ca6439f50150fc411b/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/d76d554dba67fbbdef6070ca6439f50150fc411b/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d76d554dba67fbbdef6070ca6439f50150fc411b/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/05c9fae5d8a1a3fd0d6a6e48ecc28d50d0e1bf18/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/05c9fae5d8a1a3fd0d6a6e48ecc28d50d0e1bf18/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/05c9fae5d8a1a3fd0d6a6e48ecc28d50d0e1bf18/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d76d554dba67fbbdef6070ca6439f50150fc411b/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/05c9fae5d8a1a3fd0d6a6e48ecc28d50d0e1bf18/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d76d554dba67fbbdef6070ca6439f50150fc411b/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/05c9fae5d8a1a3fd0d6a6e48ecc28d50d0e1bf18/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -1198,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/0d437d24b7c55290f0a2983955d6f65bfa89d680/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/4ea144e74373d4c40f2c225e1f4627e154c7f723/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/0d437d24b7c55290f0a2983955d6f65bfa89d680/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/4ea144e74373d4c40f2c225e1f4627e154c7f723/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0d437d24b7c55290f0a2983955d6f65bfa89d680/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4ea144e74373d4c40f2c225e1f4627e154c7f723/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/0d437d24b7c55290f0a2983955d6f65bfa89d680/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/0d437d24b7c55290f0a2983955d6f65bfa89d680/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0d437d24b7c55290f0a2983955d6f65bfa89d680/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/4ea144e74373d4c40f2c225e1f4627e154c7f723/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/4ea144e74373d4c40f2c225e1f4627e154c7f723/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4ea144e74373d4c40f2c225e1f4627e154c7f723/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0d437d24b7c55290f0a2983955d6f65bfa89d680/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4ea144e74373d4c40f2c225e1f4627e154c7f723/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0d437d24b7c55290f0a2983955d6f65bfa89d680/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4ea144e74373d4c40f2c225e1f4627e154c7f723/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -1198,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/8629bb210c20eb5ec861dd72ff5a43d3aead2756/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/b74084eba4ce055f34d6f2daa5de7d980ec8e0c3/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/8629bb210c20eb5ec861dd72ff5a43d3aead2756/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/b74084eba4ce055f34d6f2daa5de7d980ec8e0c3/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8629bb210c20eb5ec861dd72ff5a43d3aead2756/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b74084eba4ce055f34d6f2daa5de7d980ec8e0c3/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/8629bb210c20eb5ec861dd72ff5a43d3aead2756/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/8629bb210c20eb5ec861dd72ff5a43d3aead2756/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8629bb210c20eb5ec861dd72ff5a43d3aead2756/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/b74084eba4ce055f34d6f2daa5de7d980ec8e0c3/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/b74084eba4ce055f34d6f2daa5de7d980ec8e0c3/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b74084eba4ce055f34d6f2daa5de7d980ec8e0c3/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8629bb210c20eb5ec861dd72ff5a43d3aead2756/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b74084eba4ce055f34d6f2daa5de7d980ec8e0c3/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8629bb210c20eb5ec861dd72ff5a43d3aead2756/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b74084eba4ce055f34d6f2daa5de7d980ec8e0c3/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/x86_64-unknown-freebsd13.2.jl
+++ b/lib/x86_64-unknown-freebsd13.2.jl
@@ -1198,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/f6021f2d5657b72a0e75423cfc36816a35c153c9/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/e7d9db0086506a44b82ce20607f9a343716d269d/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/f6021f2d5657b72a0e75423cfc36816a35c153c9/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/e7d9db0086506a44b82ce20607f9a343716d269d/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f6021f2d5657b72a0e75423cfc36816a35c153c9/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e7d9db0086506a44b82ce20607f9a343716d269d/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/f6021f2d5657b72a0e75423cfc36816a35c153c9/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/f6021f2d5657b72a0e75423cfc36816a35c153c9/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f6021f2d5657b72a0e75423cfc36816a35c153c9/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/e7d9db0086506a44b82ce20607f9a343716d269d/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/e7d9db0086506a44b82ce20607f9a343716d269d/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e7d9db0086506a44b82ce20607f9a343716d269d/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f6021f2d5657b72a0e75423cfc36816a35c153c9/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e7d9db0086506a44b82ce20607f9a343716d269d/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f6021f2d5657b72a0e75423cfc36816a35c153c9/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e7d9db0086506a44b82ce20607f9a343716d269d/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -1198,28 +1198,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/1ae63f888fd56002cbce19aa79ca7d7e3edc01c5/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/6aa1045ab20fe09f25bbd802a4df1eddecfb10ed/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/1ae63f888fd56002cbce19aa79ca7d7e3edc01c5/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/6aa1045ab20fe09f25bbd802a4df1eddecfb10ed/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1ae63f888fd56002cbce19aa79ca7d7e3edc01c5/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6aa1045ab20fe09f25bbd802a4df1eddecfb10ed/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/1ae63f888fd56002cbce19aa79ca7d7e3edc01c5/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/1ae63f888fd56002cbce19aa79ca7d7e3edc01c5/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1ae63f888fd56002cbce19aa79ca7d7e3edc01c5/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/6aa1045ab20fe09f25bbd802a4df1eddecfb10ed/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/6aa1045ab20fe09f25bbd802a4df1eddecfb10ed/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6aa1045ab20fe09f25bbd802a4df1eddecfb10ed/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1ae63f888fd56002cbce19aa79ca7d7e3edc01c5/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6aa1045ab20fe09f25bbd802a4df1eddecfb10ed/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1235,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1ae63f888fd56002cbce19aa79ca7d7e3edc01c5/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6aa1045ab20fe09f25bbd802a4df1eddecfb10ed/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_http_jll** to version **0.9.7**
- Updated **JuliaServices/LibAwsHTTP.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings