### PR TITLE
Update aws_c_http_jll to version 0.10.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsHTTP"
 uuid = "ce851869-0d7a-41e7-95ef-2d4cb63876dd"
-version = "1.2.3"
+version = "1.2.4"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -17,7 +17,7 @@ LibAwsCal = "1.1"
 LibAwsCommon = "1.2"
 LibAwsCompression = "1.1"
 LibAwsIO = "1.2"
-aws_c_http_jll = "=0.9.7"
+aws_c_http_jll = "=0.10.0"
 julia = "1.6"
 
 [extras]

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -14,4 +14,4 @@ aws_c_io_jll = "13c41daa-f319-5298-b5eb-5754e0170d52"
 [compat]
 Clang = "0.18.3"
 JLLPrefixes = "0.3"
-aws_c_http_jll = "=0.9.7"
+aws_c_http_jll = "=0.10.0"

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/ed9521372c18e62eb942333df78a3ec2b873df95/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/79615f8f624a5bbd68357a19919186fbdb5d0fe9/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/ed9521372c18e62eb942333df78a3ec2b873df95/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/79615f8f624a5bbd68357a19919186fbdb5d0fe9/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ed9521372c18e62eb942333df78a3ec2b873df95/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/79615f8f624a5bbd68357a19919186fbdb5d0fe9/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/ed9521372c18e62eb942333df78a3ec2b873df95/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/ed9521372c18e62eb942333df78a3ec2b873df95/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ed9521372c18e62eb942333df78a3ec2b873df95/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/79615f8f624a5bbd68357a19919186fbdb5d0fe9/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/79615f8f624a5bbd68357a19919186fbdb5d0fe9/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/79615f8f624a5bbd68357a19919186fbdb5d0fe9/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ed9521372c18e62eb942333df78a3ec2b873df95/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/79615f8f624a5bbd68357a19919186fbdb5d0fe9/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ed9521372c18e62eb942333df78a3ec2b873df95/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/79615f8f624a5bbd68357a19919186fbdb5d0fe9/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -2940,6 +2945,8 @@ Increment the stream's flow-control window to keep data flowing.
 If the connection was created with `manual_window_management` set true, the flow-control window of each stream will shrink as body data is received (headers, padding, and other metadata do not affect the window). The connection's `initial_window_size` determines the starting size of each stream's window. If a stream's flow-control window reaches 0, no further data will be received.
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
+
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
 
 ### Prototype
 ```c

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/9ff8e5d46f663732c78d562a9684e8a7d066ee81/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/0cc0c51300ef6403670a55e3cbb82e66a8dc0857/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/9ff8e5d46f663732c78d562a9684e8a7d066ee81/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/0cc0c51300ef6403670a55e3cbb82e66a8dc0857/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9ff8e5d46f663732c78d562a9684e8a7d066ee81/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0cc0c51300ef6403670a55e3cbb82e66a8dc0857/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/9ff8e5d46f663732c78d562a9684e8a7d066ee81/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/9ff8e5d46f663732c78d562a9684e8a7d066ee81/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9ff8e5d46f663732c78d562a9684e8a7d066ee81/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/0cc0c51300ef6403670a55e3cbb82e66a8dc0857/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/0cc0c51300ef6403670a55e3cbb82e66a8dc0857/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0cc0c51300ef6403670a55e3cbb82e66a8dc0857/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9ff8e5d46f663732c78d562a9684e8a7d066ee81/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0cc0c51300ef6403670a55e3cbb82e66a8dc0857/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9ff8e5d46f663732c78d562a9684e8a7d066ee81/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0cc0c51300ef6403670a55e3cbb82e66a8dc0857/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -2940,6 +2945,8 @@ Increment the stream's flow-control window to keep data flowing.
 If the connection was created with `manual_window_management` set true, the flow-control window of each stream will shrink as body data is received (headers, padding, and other metadata do not affect the window). The connection's `initial_window_size` determines the starting size of each stream's window. If a stream's flow-control window reaches 0, no further data will be received.
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
+
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
 
 ### Prototype
 ```c

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/202b5e198dac9cd69d392ca209eab188e1acea6a/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/366dd4a64405ec0b5ad329bc792e5e9ce78d324d/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/202b5e198dac9cd69d392ca209eab188e1acea6a/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/366dd4a64405ec0b5ad329bc792e5e9ce78d324d/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/202b5e198dac9cd69d392ca209eab188e1acea6a/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/366dd4a64405ec0b5ad329bc792e5e9ce78d324d/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/202b5e198dac9cd69d392ca209eab188e1acea6a/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/202b5e198dac9cd69d392ca209eab188e1acea6a/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/202b5e198dac9cd69d392ca209eab188e1acea6a/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/366dd4a64405ec0b5ad329bc792e5e9ce78d324d/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/366dd4a64405ec0b5ad329bc792e5e9ce78d324d/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/366dd4a64405ec0b5ad329bc792e5e9ce78d324d/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/202b5e198dac9cd69d392ca209eab188e1acea6a/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/366dd4a64405ec0b5ad329bc792e5e9ce78d324d/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/202b5e198dac9cd69d392ca209eab188e1acea6a/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/366dd4a64405ec0b5ad329bc792e5e9ce78d324d/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -2940,6 +2945,8 @@ Increment the stream's flow-control window to keep data flowing.
 If the connection was created with `manual_window_management` set true, the flow-control window of each stream will shrink as body data is received (headers, padding, and other metadata do not affect the window). The connection's `initial_window_size` determines the starting size of each stream's window. If a stream's flow-control window reaches 0, no further data will be received.
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
+
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
 
 ### Prototype
 ```c

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/5f7d3b85932daaf94a4f435c280c0f94f6beaa11/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/0e0595ae438b054e1033a699fe6339ab51b8c8e1/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/5f7d3b85932daaf94a4f435c280c0f94f6beaa11/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/0e0595ae438b054e1033a699fe6339ab51b8c8e1/include/aws/http/proxy.h:302:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5f7d3b85932daaf94a4f435c280c0f94f6beaa11/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0e0595ae438b054e1033a699fe6339ab51b8c8e1/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/5f7d3b85932daaf94a4f435c280c0f94f6beaa11/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/5f7d3b85932daaf94a4f435c280c0f94f6beaa11/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5f7d3b85932daaf94a4f435c280c0f94f6beaa11/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/0e0595ae438b054e1033a699fe6339ab51b8c8e1/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/0e0595ae438b054e1033a699fe6339ab51b8c8e1/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0e0595ae438b054e1033a699fe6339ab51b8c8e1/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5f7d3b85932daaf94a4f435c280c0f94f6beaa11/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0e0595ae438b054e1033a699fe6339ab51b8c8e1/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5f7d3b85932daaf94a4f435c280c0f94f6beaa11/include/aws/http/proxy.h:302:5)"}(x + 16)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0e0595ae438b054e1033a699fe6339ab51b8c8e1/include/aws/http/proxy.h:302:5)"}(x + 16)
     return getfield(x, f)
 end
 
@@ -2940,6 +2945,8 @@ Increment the stream's flow-control window to keep data flowing.
 If the connection was created with `manual_window_management` set true, the flow-control window of each stream will shrink as body data is received (headers, padding, and other metadata do not affect the window). The connection's `initial_window_size` determines the starting size of each stream's window. If a stream's flow-control window reaches 0, no further data will be received.
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
+
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
 
 ### Prototype
 ```c

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/4bde5be8cca585e18ad5dde33f53c648861cf8d8/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/3813987cee7ab91aeee1de47476aa4db3905223f/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/4bde5be8cca585e18ad5dde33f53c648861cf8d8/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/3813987cee7ab91aeee1de47476aa4db3905223f/include/aws/http/proxy.h:302:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4bde5be8cca585e18ad5dde33f53c648861cf8d8/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3813987cee7ab91aeee1de47476aa4db3905223f/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/4bde5be8cca585e18ad5dde33f53c648861cf8d8/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/4bde5be8cca585e18ad5dde33f53c648861cf8d8/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4bde5be8cca585e18ad5dde33f53c648861cf8d8/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/3813987cee7ab91aeee1de47476aa4db3905223f/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/3813987cee7ab91aeee1de47476aa4db3905223f/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3813987cee7ab91aeee1de47476aa4db3905223f/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4bde5be8cca585e18ad5dde33f53c648861cf8d8/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3813987cee7ab91aeee1de47476aa4db3905223f/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4bde5be8cca585e18ad5dde33f53c648861cf8d8/include/aws/http/proxy.h:302:5)"}(x + 16)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3813987cee7ab91aeee1de47476aa4db3905223f/include/aws/http/proxy.h:302:5)"}(x + 16)
     return getfield(x, f)
 end
 
@@ -2940,6 +2945,8 @@ Increment the stream's flow-control window to keep data flowing.
 If the connection was created with `manual_window_management` set true, the flow-control window of each stream will shrink as body data is received (headers, padding, and other metadata do not affect the window). The connection's `initial_window_size` determines the starting size of each stream's window. If a stream's flow-control window reaches 0, no further data will be received.
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
+
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
 
 ### Prototype
 ```c

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/53696acfca00170545e4e289259e14c710b9076c/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/5d6c499df7b58e53cc2d67a9fdf082e6912e9e23/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/53696acfca00170545e4e289259e14c710b9076c/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/5d6c499df7b58e53cc2d67a9fdf082e6912e9e23/include/aws/http/proxy.h:302:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/53696acfca00170545e4e289259e14c710b9076c/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5d6c499df7b58e53cc2d67a9fdf082e6912e9e23/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/53696acfca00170545e4e289259e14c710b9076c/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/53696acfca00170545e4e289259e14c710b9076c/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/53696acfca00170545e4e289259e14c710b9076c/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/5d6c499df7b58e53cc2d67a9fdf082e6912e9e23/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/5d6c499df7b58e53cc2d67a9fdf082e6912e9e23/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5d6c499df7b58e53cc2d67a9fdf082e6912e9e23/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/53696acfca00170545e4e289259e14c710b9076c/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5d6c499df7b58e53cc2d67a9fdf082e6912e9e23/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/53696acfca00170545e4e289259e14c710b9076c/include/aws/http/proxy.h:302:5)"}(x + 16)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5d6c499df7b58e53cc2d67a9fdf082e6912e9e23/include/aws/http/proxy.h:302:5)"}(x + 16)
     return getfield(x, f)
 end
 
@@ -2940,6 +2945,8 @@ Increment the stream's flow-control window to keep data flowing.
 If the connection was created with `manual_window_management` set true, the flow-control window of each stream will shrink as body data is received (headers, padding, and other metadata do not affect the window). The connection's `initial_window_size` determines the starting size of each stream's window. If a stream's flow-control window reaches 0, no further data will be received.
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
+
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
 
 ### Prototype
 ```c

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/8f2f0c33139094fbda3205c022c40f654ee21dc4/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/74d8893a58da3e394c6fa226e97aa45927fc9f57/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/8f2f0c33139094fbda3205c022c40f654ee21dc4/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/74d8893a58da3e394c6fa226e97aa45927fc9f57/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8f2f0c33139094fbda3205c022c40f654ee21dc4/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/74d8893a58da3e394c6fa226e97aa45927fc9f57/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/8f2f0c33139094fbda3205c022c40f654ee21dc4/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/8f2f0c33139094fbda3205c022c40f654ee21dc4/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8f2f0c33139094fbda3205c022c40f654ee21dc4/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/74d8893a58da3e394c6fa226e97aa45927fc9f57/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/74d8893a58da3e394c6fa226e97aa45927fc9f57/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/74d8893a58da3e394c6fa226e97aa45927fc9f57/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8f2f0c33139094fbda3205c022c40f654ee21dc4/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/74d8893a58da3e394c6fa226e97aa45927fc9f57/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8f2f0c33139094fbda3205c022c40f654ee21dc4/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/74d8893a58da3e394c6fa226e97aa45927fc9f57/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -2940,6 +2945,8 @@ Increment the stream's flow-control window to keep data flowing.
 If the connection was created with `manual_window_management` set true, the flow-control window of each stream will shrink as body data is received (headers, padding, and other metadata do not affect the window). The connection's `initial_window_size` determines the starting size of each stream's window. If a stream's flow-control window reaches 0, no further data will be received.
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
+
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
 
 ### Prototype
 ```c

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/05c9fae5d8a1a3fd0d6a6e48ecc28d50d0e1bf18/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/cc99cb185151fe888dacd789152b860b186958ce/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/05c9fae5d8a1a3fd0d6a6e48ecc28d50d0e1bf18/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/cc99cb185151fe888dacd789152b860b186958ce/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/05c9fae5d8a1a3fd0d6a6e48ecc28d50d0e1bf18/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cc99cb185151fe888dacd789152b860b186958ce/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/05c9fae5d8a1a3fd0d6a6e48ecc28d50d0e1bf18/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/05c9fae5d8a1a3fd0d6a6e48ecc28d50d0e1bf18/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/05c9fae5d8a1a3fd0d6a6e48ecc28d50d0e1bf18/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/cc99cb185151fe888dacd789152b860b186958ce/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/cc99cb185151fe888dacd789152b860b186958ce/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cc99cb185151fe888dacd789152b860b186958ce/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/05c9fae5d8a1a3fd0d6a6e48ecc28d50d0e1bf18/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cc99cb185151fe888dacd789152b860b186958ce/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/05c9fae5d8a1a3fd0d6a6e48ecc28d50d0e1bf18/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cc99cb185151fe888dacd789152b860b186958ce/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -2940,6 +2945,8 @@ Increment the stream's flow-control window to keep data flowing.
 If the connection was created with `manual_window_management` set true, the flow-control window of each stream will shrink as body data is received (headers, padding, and other metadata do not affect the window). The connection's `initial_window_size` determines the starting size of each stream's window. If a stream's flow-control window reaches 0, no further data will be received.
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
+
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
 
 ### Prototype
 ```c

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/4ea144e74373d4c40f2c225e1f4627e154c7f723/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/bec3ae1fb757911326dda1c646ca96f78b040356/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/4ea144e74373d4c40f2c225e1f4627e154c7f723/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/bec3ae1fb757911326dda1c646ca96f78b040356/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4ea144e74373d4c40f2c225e1f4627e154c7f723/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bec3ae1fb757911326dda1c646ca96f78b040356/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/4ea144e74373d4c40f2c225e1f4627e154c7f723/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/4ea144e74373d4c40f2c225e1f4627e154c7f723/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4ea144e74373d4c40f2c225e1f4627e154c7f723/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/bec3ae1fb757911326dda1c646ca96f78b040356/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/bec3ae1fb757911326dda1c646ca96f78b040356/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bec3ae1fb757911326dda1c646ca96f78b040356/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4ea144e74373d4c40f2c225e1f4627e154c7f723/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bec3ae1fb757911326dda1c646ca96f78b040356/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4ea144e74373d4c40f2c225e1f4627e154c7f723/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bec3ae1fb757911326dda1c646ca96f78b040356/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -2940,6 +2945,8 @@ Increment the stream's flow-control window to keep data flowing.
 If the connection was created with `manual_window_management` set true, the flow-control window of each stream will shrink as body data is received (headers, padding, and other metadata do not affect the window). The connection's `initial_window_size` determines the starting size of each stream's window. If a stream's flow-control window reaches 0, no further data will be received.
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
+
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
 
 ### Prototype
 ```c

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/b74084eba4ce055f34d6f2daa5de7d980ec8e0c3/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/9261de762184ef54655131f949fcca23cd095811/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/b74084eba4ce055f34d6f2daa5de7d980ec8e0c3/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/9261de762184ef54655131f949fcca23cd095811/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b74084eba4ce055f34d6f2daa5de7d980ec8e0c3/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9261de762184ef54655131f949fcca23cd095811/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/b74084eba4ce055f34d6f2daa5de7d980ec8e0c3/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/b74084eba4ce055f34d6f2daa5de7d980ec8e0c3/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b74084eba4ce055f34d6f2daa5de7d980ec8e0c3/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/9261de762184ef54655131f949fcca23cd095811/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/9261de762184ef54655131f949fcca23cd095811/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9261de762184ef54655131f949fcca23cd095811/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b74084eba4ce055f34d6f2daa5de7d980ec8e0c3/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9261de762184ef54655131f949fcca23cd095811/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b74084eba4ce055f34d6f2daa5de7d980ec8e0c3/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9261de762184ef54655131f949fcca23cd095811/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -2940,6 +2945,8 @@ Increment the stream's flow-control window to keep data flowing.
 If the connection was created with `manual_window_management` set true, the flow-control window of each stream will shrink as body data is received (headers, padding, and other metadata do not affect the window). The connection's `initial_window_size` determines the starting size of each stream's window. If a stream's flow-control window reaches 0, no further data will be received.
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
+
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
 
 ### Prototype
 ```c

--- a/lib/x86_64-unknown-freebsd13.2.jl
+++ b/lib/x86_64-unknown-freebsd13.2.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/e7d9db0086506a44b82ce20607f9a343716d269d/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/c43074aefb49efde754c327e1a5a4e9d7fc26155/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/e7d9db0086506a44b82ce20607f9a343716d269d/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/c43074aefb49efde754c327e1a5a4e9d7fc26155/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e7d9db0086506a44b82ce20607f9a343716d269d/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c43074aefb49efde754c327e1a5a4e9d7fc26155/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/e7d9db0086506a44b82ce20607f9a343716d269d/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/e7d9db0086506a44b82ce20607f9a343716d269d/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e7d9db0086506a44b82ce20607f9a343716d269d/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/c43074aefb49efde754c327e1a5a4e9d7fc26155/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/c43074aefb49efde754c327e1a5a4e9d7fc26155/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c43074aefb49efde754c327e1a5a4e9d7fc26155/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e7d9db0086506a44b82ce20607f9a343716d269d/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c43074aefb49efde754c327e1a5a4e9d7fc26155/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e7d9db0086506a44b82ce20607f9a343716d269d/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c43074aefb49efde754c327e1a5a4e9d7fc26155/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -2940,6 +2945,8 @@ Increment the stream's flow-control window to keep data flowing.
 If the connection was created with `manual_window_management` set true, the flow-control window of each stream will shrink as body data is received (headers, padding, and other metadata do not affect the window). The connection's `initial_window_size` determines the starting size of each stream's window. If a stream's flow-control window reaches 0, no further data will be received.
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
+
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
 
 ### Prototype
 ```c

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -117,6 +117,8 @@ struct aws_http2_connection_options
     on_goaway_received::Ptr{aws_http2_on_goaway_received_fn}
     on_remote_settings_change::Ptr{aws_http2_on_remote_settings_change_fn}
     conn_manual_window_management::Bool
+    conn_window_size_threshold_to_send_update::UInt32
+    stream_window_size_threshold_to_send_update::UInt32
 end
 
 """
@@ -584,7 +586,9 @@ If `conn_manual_window_management` is false, this call will have no effect. The 
 
 If you are not connected, this call will have no effect.
 
-Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. If the increment size cause the connection flow window exceeds the Maximum size, this call will result in the connection lost.
+Crashes when the connection is not http2 connection. The limit of the Maximum Size is 2**31 - 1. And client will make sure the WINDOW\\_UPDATE frame to be valid.
+
+The client control exactly when the WINDOW\\_UPDATE frame sent. Check `conn_window_size_threshold_to_send_update` for details.
 
 # Arguments
 * `http2_connection`: HTTP/2 connection.
@@ -918,6 +922,7 @@ struct aws_http2_stream_manager_options
     max_closed_streams::Csize_t
     conn_manual_window_management::Bool
     enable_read_back_pressure::Bool
+    initial_window_size::Csize_t
     monitoring_options::Ptr{aws_http_connection_monitoring_options}
     proxy_options::Ptr{aws_http_proxy_options}
     proxy_ev_settings::Ptr{proxy_env_var_settings}
@@ -1198,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/6aa1045ab20fe09f25bbd802a4df1eddecfb10ed/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/e10f86bb95ee9cc8028693c38adafcdcf62c0c75/include/aws/http/proxy.h:302:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/6aa1045ab20fe09f25bbd802a4df1eddecfb10ed/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/e10f86bb95ee9cc8028693c38adafcdcf62c0c75/include/aws/http/proxy.h:302:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6aa1045ab20fe09f25bbd802a4df1eddecfb10ed/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e10f86bb95ee9cc8028693c38adafcdcf62c0c75/include/aws/http/proxy.h:302:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/6aa1045ab20fe09f25bbd802a4df1eddecfb10ed/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/6aa1045ab20fe09f25bbd802a4df1eddecfb10ed/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6aa1045ab20fe09f25bbd802a4df1eddecfb10ed/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/e10f86bb95ee9cc8028693c38adafcdcf62c0c75/include/aws/http/proxy.h:302:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/e10f86bb95ee9cc8028693c38adafcdcf62c0c75/include/aws/http/proxy.h:302:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e10f86bb95ee9cc8028693c38adafcdcf62c0c75/include/aws/http/proxy.h:302:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6aa1045ab20fe09f25bbd802a4df1eddecfb10ed/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e10f86bb95ee9cc8028693c38adafcdcf62c0c75/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1235,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6aa1045ab20fe09f25bbd802a4df1eddecfb10ed/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e10f86bb95ee9cc8028693c38adafcdcf62c0c75/include/aws/http/proxy.h:302:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -2940,6 +2945,8 @@ Increment the stream's flow-control window to keep data flowing.
 If the connection was created with `manual_window_management` set true, the flow-control window of each stream will shrink as body data is received (headers, padding, and other metadata do not affect the window). The connection's `initial_window_size` determines the starting size of each stream's window. If a stream's flow-control window reaches 0, no further data will be received.
 
 If `manual_window_management` is false, this call will have no effect. The connection maintains its flow-control windows such that no back-pressure is applied and data arrives as fast as possible.
+
+For HTTP/2, the client control exactly when the WINDOW\\_UPDATE frame sent. And client will make sure the WINDOW\\_UPDATE frame to be valid. Check `stream_window_size_threshold_to_send_update` for details.
 
 ### Prototype
 ```c


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_http_jll** to version **0.10.0**
- Updated **JuliaServices/LibAwsHTTP.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings