### PR TITLE
Update aws_c_http_jll to version 0.10.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsHTTP"
 uuid = "ce851869-0d7a-41e7-95ef-2d4cb63876dd"
-version = "1.2.6"
+version = "1.2.7"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -11,14 +11,15 @@ LibAwsIO = "a5388770-19df-4151-b103-3d71de896ddf"
 aws_c_http_jll = "3254fc65-9028-534d-aa9d-d76d128babc6"
 
 [compat]
-Aqua = "0.7"
+Aqua = "0.7,0.8"
 CEnum = "0.5"
 LibAwsCal = "1.1"
 LibAwsCommon = "1.2"
 LibAwsCompression = "1.1"
 LibAwsIO = "1.2"
-aws_c_http_jll = "=0.10.2"
+aws_c_http_jll = "=0.10.4"
 julia = "1.6"
+Test = "1.9"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -14,4 +14,4 @@ aws_c_io_jll = "13c41daa-f319-5298-b5eb-5754e0170d52"
 [compat]
 Clang = "0.18.3"
 JLLPrefixes = "0.3"
-aws_c_http_jll = "=0.10.2"
+aws_c_http_jll = "=0.10.4"

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -1203,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/f14b95fed03ff7dd7e050657a55a7256fc1b31d7/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/a2f66e179081a40f7f5ee2259fba9a5ea958dd5f/include/aws/http/proxy.h:304:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/f14b95fed03ff7dd7e050657a55a7256fc1b31d7/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/a2f66e179081a40f7f5ee2259fba9a5ea958dd5f/include/aws/http/proxy.h:304:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f14b95fed03ff7dd7e050657a55a7256fc1b31d7/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a2f66e179081a40f7f5ee2259fba9a5ea958dd5f/include/aws/http/proxy.h:304:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/f14b95fed03ff7dd7e050657a55a7256fc1b31d7/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/f14b95fed03ff7dd7e050657a55a7256fc1b31d7/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f14b95fed03ff7dd7e050657a55a7256fc1b31d7/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/a2f66e179081a40f7f5ee2259fba9a5ea958dd5f/include/aws/http/proxy.h:304:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/a2f66e179081a40f7f5ee2259fba9a5ea958dd5f/include/aws/http/proxy.h:304:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a2f66e179081a40f7f5ee2259fba9a5ea958dd5f/include/aws/http/proxy.h:304:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f14b95fed03ff7dd7e050657a55a7256fc1b31d7/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a2f66e179081a40f7f5ee2259fba9a5ea958dd5f/include/aws/http/proxy.h:304:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f14b95fed03ff7dd7e050657a55a7256fc1b31d7/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a2f66e179081a40f7f5ee2259fba9a5ea958dd5f/include/aws/http/proxy.h:304:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -1203,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/2cfbb797bf2d7796b30063b375a8809cb07cdf72/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/80465d7c5f7f0146d38753b5016037a0965849b2/include/aws/http/proxy.h:304:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/2cfbb797bf2d7796b30063b375a8809cb07cdf72/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/80465d7c5f7f0146d38753b5016037a0965849b2/include/aws/http/proxy.h:304:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2cfbb797bf2d7796b30063b375a8809cb07cdf72/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/80465d7c5f7f0146d38753b5016037a0965849b2/include/aws/http/proxy.h:304:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/2cfbb797bf2d7796b30063b375a8809cb07cdf72/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/2cfbb797bf2d7796b30063b375a8809cb07cdf72/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2cfbb797bf2d7796b30063b375a8809cb07cdf72/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/80465d7c5f7f0146d38753b5016037a0965849b2/include/aws/http/proxy.h:304:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/80465d7c5f7f0146d38753b5016037a0965849b2/include/aws/http/proxy.h:304:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/80465d7c5f7f0146d38753b5016037a0965849b2/include/aws/http/proxy.h:304:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2cfbb797bf2d7796b30063b375a8809cb07cdf72/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/80465d7c5f7f0146d38753b5016037a0965849b2/include/aws/http/proxy.h:304:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2cfbb797bf2d7796b30063b375a8809cb07cdf72/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/80465d7c5f7f0146d38753b5016037a0965849b2/include/aws/http/proxy.h:304:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -1203,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/c9e032329cee28710c336ac89a85c8e4e0da1411/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/88a530ae2088dbb626fd4632650a3bafef8f68ea/include/aws/http/proxy.h:304:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/c9e032329cee28710c336ac89a85c8e4e0da1411/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/88a530ae2088dbb626fd4632650a3bafef8f68ea/include/aws/http/proxy.h:304:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c9e032329cee28710c336ac89a85c8e4e0da1411/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/88a530ae2088dbb626fd4632650a3bafef8f68ea/include/aws/http/proxy.h:304:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/c9e032329cee28710c336ac89a85c8e4e0da1411/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/c9e032329cee28710c336ac89a85c8e4e0da1411/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c9e032329cee28710c336ac89a85c8e4e0da1411/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/88a530ae2088dbb626fd4632650a3bafef8f68ea/include/aws/http/proxy.h:304:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/88a530ae2088dbb626fd4632650a3bafef8f68ea/include/aws/http/proxy.h:304:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/88a530ae2088dbb626fd4632650a3bafef8f68ea/include/aws/http/proxy.h:304:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c9e032329cee28710c336ac89a85c8e4e0da1411/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/88a530ae2088dbb626fd4632650a3bafef8f68ea/include/aws/http/proxy.h:304:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c9e032329cee28710c336ac89a85c8e4e0da1411/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/88a530ae2088dbb626fd4632650a3bafef8f68ea/include/aws/http/proxy.h:304:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -1203,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/1296358e996ea911d843d7120ab511388b099555/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/d223865603d78d58ded272fb3a0bd9859655857b/include/aws/http/proxy.h:304:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/1296358e996ea911d843d7120ab511388b099555/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/d223865603d78d58ded272fb3a0bd9859655857b/include/aws/http/proxy.h:304:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1296358e996ea911d843d7120ab511388b099555/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d223865603d78d58ded272fb3a0bd9859655857b/include/aws/http/proxy.h:304:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/1296358e996ea911d843d7120ab511388b099555/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/1296358e996ea911d843d7120ab511388b099555/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1296358e996ea911d843d7120ab511388b099555/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/d223865603d78d58ded272fb3a0bd9859655857b/include/aws/http/proxy.h:304:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/d223865603d78d58ded272fb3a0bd9859655857b/include/aws/http/proxy.h:304:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d223865603d78d58ded272fb3a0bd9859655857b/include/aws/http/proxy.h:304:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1296358e996ea911d843d7120ab511388b099555/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d223865603d78d58ded272fb3a0bd9859655857b/include/aws/http/proxy.h:304:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1296358e996ea911d843d7120ab511388b099555/include/aws/http/proxy.h:302:5)"}(x + 16)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d223865603d78d58ded272fb3a0bd9859655857b/include/aws/http/proxy.h:304:5)"}(x + 16)
     return getfield(x, f)
 end
 

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -1203,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/56242a60ba54d6b36330bf9ed8c308071a11767f/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/177be0b6aa14793f56a1f87152f72aa8234c3b46/include/aws/http/proxy.h:304:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/56242a60ba54d6b36330bf9ed8c308071a11767f/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/177be0b6aa14793f56a1f87152f72aa8234c3b46/include/aws/http/proxy.h:304:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/56242a60ba54d6b36330bf9ed8c308071a11767f/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/177be0b6aa14793f56a1f87152f72aa8234c3b46/include/aws/http/proxy.h:304:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/56242a60ba54d6b36330bf9ed8c308071a11767f/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/56242a60ba54d6b36330bf9ed8c308071a11767f/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/56242a60ba54d6b36330bf9ed8c308071a11767f/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/177be0b6aa14793f56a1f87152f72aa8234c3b46/include/aws/http/proxy.h:304:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/177be0b6aa14793f56a1f87152f72aa8234c3b46/include/aws/http/proxy.h:304:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/177be0b6aa14793f56a1f87152f72aa8234c3b46/include/aws/http/proxy.h:304:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/56242a60ba54d6b36330bf9ed8c308071a11767f/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/177be0b6aa14793f56a1f87152f72aa8234c3b46/include/aws/http/proxy.h:304:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/56242a60ba54d6b36330bf9ed8c308071a11767f/include/aws/http/proxy.h:302:5)"}(x + 16)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/177be0b6aa14793f56a1f87152f72aa8234c3b46/include/aws/http/proxy.h:304:5)"}(x + 16)
     return getfield(x, f)
 end
 

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -1203,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/f1d78d47c2ea88e74f53958019fa090577d1df40/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/6d205a518806858f0fd9fd4ccdbd4fbb85f0f741/include/aws/http/proxy.h:304:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/f1d78d47c2ea88e74f53958019fa090577d1df40/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/6d205a518806858f0fd9fd4ccdbd4fbb85f0f741/include/aws/http/proxy.h:304:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f1d78d47c2ea88e74f53958019fa090577d1df40/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6d205a518806858f0fd9fd4ccdbd4fbb85f0f741/include/aws/http/proxy.h:304:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/f1d78d47c2ea88e74f53958019fa090577d1df40/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/f1d78d47c2ea88e74f53958019fa090577d1df40/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f1d78d47c2ea88e74f53958019fa090577d1df40/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/6d205a518806858f0fd9fd4ccdbd4fbb85f0f741/include/aws/http/proxy.h:304:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/6d205a518806858f0fd9fd4ccdbd4fbb85f0f741/include/aws/http/proxy.h:304:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6d205a518806858f0fd9fd4ccdbd4fbb85f0f741/include/aws/http/proxy.h:304:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f1d78d47c2ea88e74f53958019fa090577d1df40/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6d205a518806858f0fd9fd4ccdbd4fbb85f0f741/include/aws/http/proxy.h:304:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f1d78d47c2ea88e74f53958019fa090577d1df40/include/aws/http/proxy.h:302:5)"}(x + 16)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6d205a518806858f0fd9fd4ccdbd4fbb85f0f741/include/aws/http/proxy.h:304:5)"}(x + 16)
     return getfield(x, f)
 end
 

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -1203,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/dca911c7c6e44ee56e73869c0c2cced88428ec42/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/9834d1826f5d877902c36451e15865cda4c3e933/include/aws/http/proxy.h:304:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/dca911c7c6e44ee56e73869c0c2cced88428ec42/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/9834d1826f5d877902c36451e15865cda4c3e933/include/aws/http/proxy.h:304:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/dca911c7c6e44ee56e73869c0c2cced88428ec42/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9834d1826f5d877902c36451e15865cda4c3e933/include/aws/http/proxy.h:304:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/dca911c7c6e44ee56e73869c0c2cced88428ec42/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/dca911c7c6e44ee56e73869c0c2cced88428ec42/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/dca911c7c6e44ee56e73869c0c2cced88428ec42/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/9834d1826f5d877902c36451e15865cda4c3e933/include/aws/http/proxy.h:304:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/9834d1826f5d877902c36451e15865cda4c3e933/include/aws/http/proxy.h:304:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9834d1826f5d877902c36451e15865cda4c3e933/include/aws/http/proxy.h:304:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/dca911c7c6e44ee56e73869c0c2cced88428ec42/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9834d1826f5d877902c36451e15865cda4c3e933/include/aws/http/proxy.h:304:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/dca911c7c6e44ee56e73869c0c2cced88428ec42/include/aws/http/proxy.h:302:5)"}(x + 16)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9834d1826f5d877902c36451e15865cda4c3e933/include/aws/http/proxy.h:304:5)"}(x + 16)
     return getfield(x, f)
 end
 

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -1203,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/51eab4da1349c38b708a7bbcab070a4090bb2560/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/25f7234592c737021091f9c3ca2c3c9ced3d1f69/include/aws/http/proxy.h:304:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/51eab4da1349c38b708a7bbcab070a4090bb2560/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/25f7234592c737021091f9c3ca2c3c9ced3d1f69/include/aws/http/proxy.h:304:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/51eab4da1349c38b708a7bbcab070a4090bb2560/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/25f7234592c737021091f9c3ca2c3c9ced3d1f69/include/aws/http/proxy.h:304:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/51eab4da1349c38b708a7bbcab070a4090bb2560/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/51eab4da1349c38b708a7bbcab070a4090bb2560/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/51eab4da1349c38b708a7bbcab070a4090bb2560/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/25f7234592c737021091f9c3ca2c3c9ced3d1f69/include/aws/http/proxy.h:304:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/25f7234592c737021091f9c3ca2c3c9ced3d1f69/include/aws/http/proxy.h:304:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/25f7234592c737021091f9c3ca2c3c9ced3d1f69/include/aws/http/proxy.h:304:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/51eab4da1349c38b708a7bbcab070a4090bb2560/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/25f7234592c737021091f9c3ca2c3c9ced3d1f69/include/aws/http/proxy.h:304:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/51eab4da1349c38b708a7bbcab070a4090bb2560/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/25f7234592c737021091f9c3ca2c3c9ced3d1f69/include/aws/http/proxy.h:304:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -1203,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/4491a1d8da093e8821522bb3d8c58a1282d14515/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/cfdadd8d6fe3a580299b0cc00f067a0d6d752825/include/aws/http/proxy.h:304:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/4491a1d8da093e8821522bb3d8c58a1282d14515/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/cfdadd8d6fe3a580299b0cc00f067a0d6d752825/include/aws/http/proxy.h:304:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4491a1d8da093e8821522bb3d8c58a1282d14515/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cfdadd8d6fe3a580299b0cc00f067a0d6d752825/include/aws/http/proxy.h:304:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/4491a1d8da093e8821522bb3d8c58a1282d14515/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/4491a1d8da093e8821522bb3d8c58a1282d14515/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4491a1d8da093e8821522bb3d8c58a1282d14515/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/cfdadd8d6fe3a580299b0cc00f067a0d6d752825/include/aws/http/proxy.h:304:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/cfdadd8d6fe3a580299b0cc00f067a0d6d752825/include/aws/http/proxy.h:304:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cfdadd8d6fe3a580299b0cc00f067a0d6d752825/include/aws/http/proxy.h:304:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4491a1d8da093e8821522bb3d8c58a1282d14515/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cfdadd8d6fe3a580299b0cc00f067a0d6d752825/include/aws/http/proxy.h:304:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4491a1d8da093e8821522bb3d8c58a1282d14515/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cfdadd8d6fe3a580299b0cc00f067a0d6d752825/include/aws/http/proxy.h:304:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -1203,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/8272ee2139312cb2564180e6c2afd8b3818f4a87/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/aebb923eb82bc5190f95ab05d8dcc8f5637ae9bf/include/aws/http/proxy.h:304:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/8272ee2139312cb2564180e6c2afd8b3818f4a87/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/aebb923eb82bc5190f95ab05d8dcc8f5637ae9bf/include/aws/http/proxy.h:304:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8272ee2139312cb2564180e6c2afd8b3818f4a87/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/aebb923eb82bc5190f95ab05d8dcc8f5637ae9bf/include/aws/http/proxy.h:304:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/8272ee2139312cb2564180e6c2afd8b3818f4a87/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/8272ee2139312cb2564180e6c2afd8b3818f4a87/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8272ee2139312cb2564180e6c2afd8b3818f4a87/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/aebb923eb82bc5190f95ab05d8dcc8f5637ae9bf/include/aws/http/proxy.h:304:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/aebb923eb82bc5190f95ab05d8dcc8f5637ae9bf/include/aws/http/proxy.h:304:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/aebb923eb82bc5190f95ab05d8dcc8f5637ae9bf/include/aws/http/proxy.h:304:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8272ee2139312cb2564180e6c2afd8b3818f4a87/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/aebb923eb82bc5190f95ab05d8dcc8f5637ae9bf/include/aws/http/proxy.h:304:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8272ee2139312cb2564180e6c2afd8b3818f4a87/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/aebb923eb82bc5190f95ab05d8dcc8f5637ae9bf/include/aws/http/proxy.h:304:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -1203,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/12e6186f1c8e9841ef05c331f66243b7dc964cfd/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/d893b03dcc725a2e6cb6641240fe9a80345ebe4c/include/aws/http/proxy.h:304:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/12e6186f1c8e9841ef05c331f66243b7dc964cfd/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/d893b03dcc725a2e6cb6641240fe9a80345ebe4c/include/aws/http/proxy.h:304:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/12e6186f1c8e9841ef05c331f66243b7dc964cfd/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d893b03dcc725a2e6cb6641240fe9a80345ebe4c/include/aws/http/proxy.h:304:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/12e6186f1c8e9841ef05c331f66243b7dc964cfd/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/12e6186f1c8e9841ef05c331f66243b7dc964cfd/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/12e6186f1c8e9841ef05c331f66243b7dc964cfd/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/d893b03dcc725a2e6cb6641240fe9a80345ebe4c/include/aws/http/proxy.h:304:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/d893b03dcc725a2e6cb6641240fe9a80345ebe4c/include/aws/http/proxy.h:304:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d893b03dcc725a2e6cb6641240fe9a80345ebe4c/include/aws/http/proxy.h:304:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/12e6186f1c8e9841ef05c331f66243b7dc964cfd/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d893b03dcc725a2e6cb6641240fe9a80345ebe4c/include/aws/http/proxy.h:304:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/12e6186f1c8e9841ef05c331f66243b7dc964cfd/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d893b03dcc725a2e6cb6641240fe9a80345ebe4c/include/aws/http/proxy.h:304:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/x86_64-unknown-freebsd13.2.jl
+++ b/lib/x86_64-unknown-freebsd13.2.jl
@@ -1203,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/d13d15cbd22d5cd5a4d4f413d04ffd231aad3f3a/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/b6d7440da36d72b158c0f4b4dcc81c64f0d43ad1/include/aws/http/proxy.h:304:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/d13d15cbd22d5cd5a4d4f413d04ffd231aad3f3a/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/b6d7440da36d72b158c0f4b4dcc81c64f0d43ad1/include/aws/http/proxy.h:304:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d13d15cbd22d5cd5a4d4f413d04ffd231aad3f3a/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b6d7440da36d72b158c0f4b4dcc81c64f0d43ad1/include/aws/http/proxy.h:304:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/d13d15cbd22d5cd5a4d4f413d04ffd231aad3f3a/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/d13d15cbd22d5cd5a4d4f413d04ffd231aad3f3a/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d13d15cbd22d5cd5a4d4f413d04ffd231aad3f3a/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/b6d7440da36d72b158c0f4b4dcc81c64f0d43ad1/include/aws/http/proxy.h:304:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/b6d7440da36d72b158c0f4b4dcc81c64f0d43ad1/include/aws/http/proxy.h:304:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b6d7440da36d72b158c0f4b4dcc81c64f0d43ad1/include/aws/http/proxy.h:304:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d13d15cbd22d5cd5a4d4f413d04ffd231aad3f3a/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b6d7440da36d72b158c0f4b4dcc81c64f0d43ad1/include/aws/http/proxy.h:304:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d13d15cbd22d5cd5a4d4f413d04ffd231aad3f3a/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b6d7440da36d72b158c0f4b4dcc81c64f0d43ad1/include/aws/http/proxy.h:304:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -1203,28 +1203,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/04eed940a9591d301663dc6025ef0782e86d8bcd/include/aws/http/proxy.h:302:5)
+    union (unnamed at /home/runner/.julia/artifacts/6a7e6ff6fe9495625e928adb6f322cef8b38cf07/include/aws/http/proxy.h:304:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/04eed940a9591d301663dc6025ef0782e86d8bcd/include/aws/http/proxy.h:302:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/6a7e6ff6fe9495625e928adb6f322cef8b38cf07/include/aws/http/proxy.h:304:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/04eed940a9591d301663dc6025ef0782e86d8bcd/include/aws/http/proxy.h:302:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6a7e6ff6fe9495625e928adb6f322cef8b38cf07/include/aws/http/proxy.h:304:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/04eed940a9591d301663dc6025ef0782e86d8bcd/include/aws/http/proxy.h:302:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/04eed940a9591d301663dc6025ef0782e86d8bcd/include/aws/http/proxy.h:302:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/04eed940a9591d301663dc6025ef0782e86d8bcd/include/aws/http/proxy.h:302:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/6a7e6ff6fe9495625e928adb6f322cef8b38cf07/include/aws/http/proxy.h:304:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/6a7e6ff6fe9495625e928adb6f322cef8b38cf07/include/aws/http/proxy.h:304:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6a7e6ff6fe9495625e928adb6f322cef8b38cf07/include/aws/http/proxy.h:304:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/04eed940a9591d301663dc6025ef0782e86d8bcd/include/aws/http/proxy.h:302:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6a7e6ff6fe9495625e928adb6f322cef8b38cf07/include/aws/http/proxy.h:304:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1240,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/04eed940a9591d301663dc6025ef0782e86d8bcd/include/aws/http/proxy.h:302:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6a7e6ff6fe9495625e928adb6f322cef8b38cf07/include/aws/http/proxy.h:304:5)"}(x + 32)
     return getfield(x, f)
 end
 


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_http_jll** to version **0.10.4**
- Updated **JuliaServices/LibAwsHTTP.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings