### PR TITLE
Update aws_c_http_jll to version 0.10.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsHTTP"
 uuid = "ce851869-0d7a-41e7-95ef-2d4cb63876dd"
-version = "1.2.7"
+version = "1.2.8"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -17,7 +17,7 @@ LibAwsCal = "1.1"
 LibAwsCommon = "1.2"
 LibAwsCompression = "1.1"
 LibAwsIO = "1.2"
-aws_c_http_jll = "=0.10.4"
+aws_c_http_jll = "=0.10.6"
 julia = "1.6"
 Test = "1.9"
 

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -14,4 +14,4 @@ aws_c_io_jll = "13c41daa-f319-5298-b5eb-5754e0170d52"
 [compat]
 Clang = "0.18.3"
 JLLPrefixes = "0.3"
-aws_c_http_jll = "=0.10.4"
+aws_c_http_jll = "=0.10.6"

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -185,6 +185,7 @@ struct aws_http_proxy_options
     auth_type::aws_http_proxy_authentication_type
     auth_username::aws_byte_cursor
     auth_password::aws_byte_cursor
+    no_proxy_hosts::aws_byte_cursor
 end
 
 """
@@ -1203,28 +1204,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/a2f66e179081a40f7f5ee2259fba9a5ea958dd5f/include/aws/http/proxy.h:304:5)
+    union (unnamed at /home/runner/.julia/artifacts/6d7603c59a4501a850b45dfc8948a5171cde4b8b/include/aws/http/proxy.h:310:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/a2f66e179081a40f7f5ee2259fba9a5ea958dd5f/include/aws/http/proxy.h:304:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/6d7603c59a4501a850b45dfc8948a5171cde4b8b/include/aws/http/proxy.h:310:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a2f66e179081a40f7f5ee2259fba9a5ea958dd5f/include/aws/http/proxy.h:304:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6d7603c59a4501a850b45dfc8948a5171cde4b8b/include/aws/http/proxy.h:310:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/a2f66e179081a40f7f5ee2259fba9a5ea958dd5f/include/aws/http/proxy.h:304:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/a2f66e179081a40f7f5ee2259fba9a5ea958dd5f/include/aws/http/proxy.h:304:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a2f66e179081a40f7f5ee2259fba9a5ea958dd5f/include/aws/http/proxy.h:304:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/6d7603c59a4501a850b45dfc8948a5171cde4b8b/include/aws/http/proxy.h:310:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/6d7603c59a4501a850b45dfc8948a5171cde4b8b/include/aws/http/proxy.h:310:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6d7603c59a4501a850b45dfc8948a5171cde4b8b/include/aws/http/proxy.h:310:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a2f66e179081a40f7f5ee2259fba9a5ea958dd5f/include/aws/http/proxy.h:304:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6d7603c59a4501a850b45dfc8948a5171cde4b8b/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1241,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a2f66e179081a40f7f5ee2259fba9a5ea958dd5f/include/aws/http/proxy.h:304:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6d7603c59a4501a850b45dfc8948a5171cde4b8b/include/aws/http/proxy.h:310:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -185,6 +185,7 @@ struct aws_http_proxy_options
     auth_type::aws_http_proxy_authentication_type
     auth_username::aws_byte_cursor
     auth_password::aws_byte_cursor
+    no_proxy_hosts::aws_byte_cursor
 end
 
 """
@@ -1203,28 +1204,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/80465d7c5f7f0146d38753b5016037a0965849b2/include/aws/http/proxy.h:304:5)
+    union (unnamed at /home/runner/.julia/artifacts/037c3a29e2d275d5226a1ad23da6c2b531790198/include/aws/http/proxy.h:310:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/80465d7c5f7f0146d38753b5016037a0965849b2/include/aws/http/proxy.h:304:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/037c3a29e2d275d5226a1ad23da6c2b531790198/include/aws/http/proxy.h:310:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/80465d7c5f7f0146d38753b5016037a0965849b2/include/aws/http/proxy.h:304:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/037c3a29e2d275d5226a1ad23da6c2b531790198/include/aws/http/proxy.h:310:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/80465d7c5f7f0146d38753b5016037a0965849b2/include/aws/http/proxy.h:304:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/80465d7c5f7f0146d38753b5016037a0965849b2/include/aws/http/proxy.h:304:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/80465d7c5f7f0146d38753b5016037a0965849b2/include/aws/http/proxy.h:304:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/037c3a29e2d275d5226a1ad23da6c2b531790198/include/aws/http/proxy.h:310:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/037c3a29e2d275d5226a1ad23da6c2b531790198/include/aws/http/proxy.h:310:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/037c3a29e2d275d5226a1ad23da6c2b531790198/include/aws/http/proxy.h:310:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/80465d7c5f7f0146d38753b5016037a0965849b2/include/aws/http/proxy.h:304:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/037c3a29e2d275d5226a1ad23da6c2b531790198/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1241,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/80465d7c5f7f0146d38753b5016037a0965849b2/include/aws/http/proxy.h:304:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/037c3a29e2d275d5226a1ad23da6c2b531790198/include/aws/http/proxy.h:310:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -185,6 +185,7 @@ struct aws_http_proxy_options
     auth_type::aws_http_proxy_authentication_type
     auth_username::aws_byte_cursor
     auth_password::aws_byte_cursor
+    no_proxy_hosts::aws_byte_cursor
 end
 
 """
@@ -1203,28 +1204,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/88a530ae2088dbb626fd4632650a3bafef8f68ea/include/aws/http/proxy.h:304:5)
+    union (unnamed at /home/runner/.julia/artifacts/d8ccc286a06e70394bd760e19fc84a36e51c3dc5/include/aws/http/proxy.h:310:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/88a530ae2088dbb626fd4632650a3bafef8f68ea/include/aws/http/proxy.h:304:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/d8ccc286a06e70394bd760e19fc84a36e51c3dc5/include/aws/http/proxy.h:310:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/88a530ae2088dbb626fd4632650a3bafef8f68ea/include/aws/http/proxy.h:304:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d8ccc286a06e70394bd760e19fc84a36e51c3dc5/include/aws/http/proxy.h:310:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/88a530ae2088dbb626fd4632650a3bafef8f68ea/include/aws/http/proxy.h:304:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/88a530ae2088dbb626fd4632650a3bafef8f68ea/include/aws/http/proxy.h:304:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/88a530ae2088dbb626fd4632650a3bafef8f68ea/include/aws/http/proxy.h:304:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/d8ccc286a06e70394bd760e19fc84a36e51c3dc5/include/aws/http/proxy.h:310:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/d8ccc286a06e70394bd760e19fc84a36e51c3dc5/include/aws/http/proxy.h:310:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d8ccc286a06e70394bd760e19fc84a36e51c3dc5/include/aws/http/proxy.h:310:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/88a530ae2088dbb626fd4632650a3bafef8f68ea/include/aws/http/proxy.h:304:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d8ccc286a06e70394bd760e19fc84a36e51c3dc5/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1241,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/88a530ae2088dbb626fd4632650a3bafef8f68ea/include/aws/http/proxy.h:304:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d8ccc286a06e70394bd760e19fc84a36e51c3dc5/include/aws/http/proxy.h:310:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -185,6 +185,7 @@ struct aws_http_proxy_options
     auth_type::aws_http_proxy_authentication_type
     auth_username::aws_byte_cursor
     auth_password::aws_byte_cursor
+    no_proxy_hosts::aws_byte_cursor
 end
 
 """
@@ -1203,28 +1204,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/d223865603d78d58ded272fb3a0bd9859655857b/include/aws/http/proxy.h:304:5)
+    union (unnamed at /home/runner/.julia/artifacts/699ec37bac8353debf4eb48cdd7d868362ca767b/include/aws/http/proxy.h:310:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/d223865603d78d58ded272fb3a0bd9859655857b/include/aws/http/proxy.h:304:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/699ec37bac8353debf4eb48cdd7d868362ca767b/include/aws/http/proxy.h:310:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d223865603d78d58ded272fb3a0bd9859655857b/include/aws/http/proxy.h:304:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/699ec37bac8353debf4eb48cdd7d868362ca767b/include/aws/http/proxy.h:310:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/d223865603d78d58ded272fb3a0bd9859655857b/include/aws/http/proxy.h:304:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/d223865603d78d58ded272fb3a0bd9859655857b/include/aws/http/proxy.h:304:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d223865603d78d58ded272fb3a0bd9859655857b/include/aws/http/proxy.h:304:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/699ec37bac8353debf4eb48cdd7d868362ca767b/include/aws/http/proxy.h:310:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/699ec37bac8353debf4eb48cdd7d868362ca767b/include/aws/http/proxy.h:310:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/699ec37bac8353debf4eb48cdd7d868362ca767b/include/aws/http/proxy.h:310:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d223865603d78d58ded272fb3a0bd9859655857b/include/aws/http/proxy.h:304:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/699ec37bac8353debf4eb48cdd7d868362ca767b/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1241,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d223865603d78d58ded272fb3a0bd9859655857b/include/aws/http/proxy.h:304:5)"}(x + 16)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/699ec37bac8353debf4eb48cdd7d868362ca767b/include/aws/http/proxy.h:310:5)"}(x + 16)
     return getfield(x, f)
 end
 

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -185,6 +185,7 @@ struct aws_http_proxy_options
     auth_type::aws_http_proxy_authentication_type
     auth_username::aws_byte_cursor
     auth_password::aws_byte_cursor
+    no_proxy_hosts::aws_byte_cursor
 end
 
 """
@@ -1203,28 +1204,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/177be0b6aa14793f56a1f87152f72aa8234c3b46/include/aws/http/proxy.h:304:5)
+    union (unnamed at /home/runner/.julia/artifacts/bf9aa186eb1d6ad60c818a68e4e052adf03e5aed/include/aws/http/proxy.h:310:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/177be0b6aa14793f56a1f87152f72aa8234c3b46/include/aws/http/proxy.h:304:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/bf9aa186eb1d6ad60c818a68e4e052adf03e5aed/include/aws/http/proxy.h:310:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/177be0b6aa14793f56a1f87152f72aa8234c3b46/include/aws/http/proxy.h:304:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bf9aa186eb1d6ad60c818a68e4e052adf03e5aed/include/aws/http/proxy.h:310:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/177be0b6aa14793f56a1f87152f72aa8234c3b46/include/aws/http/proxy.h:304:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/177be0b6aa14793f56a1f87152f72aa8234c3b46/include/aws/http/proxy.h:304:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/177be0b6aa14793f56a1f87152f72aa8234c3b46/include/aws/http/proxy.h:304:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/bf9aa186eb1d6ad60c818a68e4e052adf03e5aed/include/aws/http/proxy.h:310:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/bf9aa186eb1d6ad60c818a68e4e052adf03e5aed/include/aws/http/proxy.h:310:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bf9aa186eb1d6ad60c818a68e4e052adf03e5aed/include/aws/http/proxy.h:310:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/177be0b6aa14793f56a1f87152f72aa8234c3b46/include/aws/http/proxy.h:304:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bf9aa186eb1d6ad60c818a68e4e052adf03e5aed/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1241,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/177be0b6aa14793f56a1f87152f72aa8234c3b46/include/aws/http/proxy.h:304:5)"}(x + 16)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bf9aa186eb1d6ad60c818a68e4e052adf03e5aed/include/aws/http/proxy.h:310:5)"}(x + 16)
     return getfield(x, f)
 end
 

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -185,6 +185,7 @@ struct aws_http_proxy_options
     auth_type::aws_http_proxy_authentication_type
     auth_username::aws_byte_cursor
     auth_password::aws_byte_cursor
+    no_proxy_hosts::aws_byte_cursor
 end
 
 """
@@ -1203,28 +1204,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/6d205a518806858f0fd9fd4ccdbd4fbb85f0f741/include/aws/http/proxy.h:304:5)
+    union (unnamed at /home/runner/.julia/artifacts/c0b899b922cab3e1bad8b88b0c52ce635189e6ad/include/aws/http/proxy.h:310:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/6d205a518806858f0fd9fd4ccdbd4fbb85f0f741/include/aws/http/proxy.h:304:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/c0b899b922cab3e1bad8b88b0c52ce635189e6ad/include/aws/http/proxy.h:310:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6d205a518806858f0fd9fd4ccdbd4fbb85f0f741/include/aws/http/proxy.h:304:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c0b899b922cab3e1bad8b88b0c52ce635189e6ad/include/aws/http/proxy.h:310:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/6d205a518806858f0fd9fd4ccdbd4fbb85f0f741/include/aws/http/proxy.h:304:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/6d205a518806858f0fd9fd4ccdbd4fbb85f0f741/include/aws/http/proxy.h:304:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6d205a518806858f0fd9fd4ccdbd4fbb85f0f741/include/aws/http/proxy.h:304:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/c0b899b922cab3e1bad8b88b0c52ce635189e6ad/include/aws/http/proxy.h:310:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/c0b899b922cab3e1bad8b88b0c52ce635189e6ad/include/aws/http/proxy.h:310:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c0b899b922cab3e1bad8b88b0c52ce635189e6ad/include/aws/http/proxy.h:310:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6d205a518806858f0fd9fd4ccdbd4fbb85f0f741/include/aws/http/proxy.h:304:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c0b899b922cab3e1bad8b88b0c52ce635189e6ad/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1241,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6d205a518806858f0fd9fd4ccdbd4fbb85f0f741/include/aws/http/proxy.h:304:5)"}(x + 16)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c0b899b922cab3e1bad8b88b0c52ce635189e6ad/include/aws/http/proxy.h:310:5)"}(x + 16)
     return getfield(x, f)
 end
 

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -185,6 +185,7 @@ struct aws_http_proxy_options
     auth_type::aws_http_proxy_authentication_type
     auth_username::aws_byte_cursor
     auth_password::aws_byte_cursor
+    no_proxy_hosts::aws_byte_cursor
 end
 
 """
@@ -1203,28 +1204,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/9834d1826f5d877902c36451e15865cda4c3e933/include/aws/http/proxy.h:304:5)
+    union (unnamed at /home/runner/.julia/artifacts/3c02364f88c462f406cf75cec16399fb74209907/include/aws/http/proxy.h:310:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/9834d1826f5d877902c36451e15865cda4c3e933/include/aws/http/proxy.h:304:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/3c02364f88c462f406cf75cec16399fb74209907/include/aws/http/proxy.h:310:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9834d1826f5d877902c36451e15865cda4c3e933/include/aws/http/proxy.h:304:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3c02364f88c462f406cf75cec16399fb74209907/include/aws/http/proxy.h:310:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/9834d1826f5d877902c36451e15865cda4c3e933/include/aws/http/proxy.h:304:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/9834d1826f5d877902c36451e15865cda4c3e933/include/aws/http/proxy.h:304:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9834d1826f5d877902c36451e15865cda4c3e933/include/aws/http/proxy.h:304:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/3c02364f88c462f406cf75cec16399fb74209907/include/aws/http/proxy.h:310:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/3c02364f88c462f406cf75cec16399fb74209907/include/aws/http/proxy.h:310:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3c02364f88c462f406cf75cec16399fb74209907/include/aws/http/proxy.h:310:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9834d1826f5d877902c36451e15865cda4c3e933/include/aws/http/proxy.h:304:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3c02364f88c462f406cf75cec16399fb74209907/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1241,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9834d1826f5d877902c36451e15865cda4c3e933/include/aws/http/proxy.h:304:5)"}(x + 16)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3c02364f88c462f406cf75cec16399fb74209907/include/aws/http/proxy.h:310:5)"}(x + 16)
     return getfield(x, f)
 end
 

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -185,6 +185,7 @@ struct aws_http_proxy_options
     auth_type::aws_http_proxy_authentication_type
     auth_username::aws_byte_cursor
     auth_password::aws_byte_cursor
+    no_proxy_hosts::aws_byte_cursor
 end
 
 """
@@ -1203,28 +1204,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/25f7234592c737021091f9c3ca2c3c9ced3d1f69/include/aws/http/proxy.h:304:5)
+    union (unnamed at /home/runner/.julia/artifacts/d4f342fa90cfeba5f2201a7e3875e80659ca0bfe/include/aws/http/proxy.h:310:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/25f7234592c737021091f9c3ca2c3c9ced3d1f69/include/aws/http/proxy.h:304:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/d4f342fa90cfeba5f2201a7e3875e80659ca0bfe/include/aws/http/proxy.h:310:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/25f7234592c737021091f9c3ca2c3c9ced3d1f69/include/aws/http/proxy.h:304:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d4f342fa90cfeba5f2201a7e3875e80659ca0bfe/include/aws/http/proxy.h:310:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/25f7234592c737021091f9c3ca2c3c9ced3d1f69/include/aws/http/proxy.h:304:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/25f7234592c737021091f9c3ca2c3c9ced3d1f69/include/aws/http/proxy.h:304:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/25f7234592c737021091f9c3ca2c3c9ced3d1f69/include/aws/http/proxy.h:304:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/d4f342fa90cfeba5f2201a7e3875e80659ca0bfe/include/aws/http/proxy.h:310:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/d4f342fa90cfeba5f2201a7e3875e80659ca0bfe/include/aws/http/proxy.h:310:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d4f342fa90cfeba5f2201a7e3875e80659ca0bfe/include/aws/http/proxy.h:310:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/25f7234592c737021091f9c3ca2c3c9ced3d1f69/include/aws/http/proxy.h:304:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d4f342fa90cfeba5f2201a7e3875e80659ca0bfe/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1241,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/25f7234592c737021091f9c3ca2c3c9ced3d1f69/include/aws/http/proxy.h:304:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d4f342fa90cfeba5f2201a7e3875e80659ca0bfe/include/aws/http/proxy.h:310:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -185,6 +185,7 @@ struct aws_http_proxy_options
     auth_type::aws_http_proxy_authentication_type
     auth_username::aws_byte_cursor
     auth_password::aws_byte_cursor
+    no_proxy_hosts::aws_byte_cursor
 end
 
 """
@@ -1203,28 +1204,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/cfdadd8d6fe3a580299b0cc00f067a0d6d752825/include/aws/http/proxy.h:304:5)
+    union (unnamed at /home/runner/.julia/artifacts/bb083fc2d9c8ad49a33dce760f0771407ee9f35a/include/aws/http/proxy.h:310:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/cfdadd8d6fe3a580299b0cc00f067a0d6d752825/include/aws/http/proxy.h:304:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/bb083fc2d9c8ad49a33dce760f0771407ee9f35a/include/aws/http/proxy.h:310:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cfdadd8d6fe3a580299b0cc00f067a0d6d752825/include/aws/http/proxy.h:304:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bb083fc2d9c8ad49a33dce760f0771407ee9f35a/include/aws/http/proxy.h:310:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/cfdadd8d6fe3a580299b0cc00f067a0d6d752825/include/aws/http/proxy.h:304:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/cfdadd8d6fe3a580299b0cc00f067a0d6d752825/include/aws/http/proxy.h:304:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cfdadd8d6fe3a580299b0cc00f067a0d6d752825/include/aws/http/proxy.h:304:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/bb083fc2d9c8ad49a33dce760f0771407ee9f35a/include/aws/http/proxy.h:310:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/bb083fc2d9c8ad49a33dce760f0771407ee9f35a/include/aws/http/proxy.h:310:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bb083fc2d9c8ad49a33dce760f0771407ee9f35a/include/aws/http/proxy.h:310:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cfdadd8d6fe3a580299b0cc00f067a0d6d752825/include/aws/http/proxy.h:304:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bb083fc2d9c8ad49a33dce760f0771407ee9f35a/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1241,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cfdadd8d6fe3a580299b0cc00f067a0d6d752825/include/aws/http/proxy.h:304:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bb083fc2d9c8ad49a33dce760f0771407ee9f35a/include/aws/http/proxy.h:310:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -185,6 +185,7 @@ struct aws_http_proxy_options
     auth_type::aws_http_proxy_authentication_type
     auth_username::aws_byte_cursor
     auth_password::aws_byte_cursor
+    no_proxy_hosts::aws_byte_cursor
 end
 
 """
@@ -1203,28 +1204,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/aebb923eb82bc5190f95ab05d8dcc8f5637ae9bf/include/aws/http/proxy.h:304:5)
+    union (unnamed at /home/runner/.julia/artifacts/bd33d9c370c77e08f2b316b8fe32d1d4f63c7e97/include/aws/http/proxy.h:310:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/aebb923eb82bc5190f95ab05d8dcc8f5637ae9bf/include/aws/http/proxy.h:304:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/bd33d9c370c77e08f2b316b8fe32d1d4f63c7e97/include/aws/http/proxy.h:310:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/aebb923eb82bc5190f95ab05d8dcc8f5637ae9bf/include/aws/http/proxy.h:304:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bd33d9c370c77e08f2b316b8fe32d1d4f63c7e97/include/aws/http/proxy.h:310:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/aebb923eb82bc5190f95ab05d8dcc8f5637ae9bf/include/aws/http/proxy.h:304:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/aebb923eb82bc5190f95ab05d8dcc8f5637ae9bf/include/aws/http/proxy.h:304:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/aebb923eb82bc5190f95ab05d8dcc8f5637ae9bf/include/aws/http/proxy.h:304:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/bd33d9c370c77e08f2b316b8fe32d1d4f63c7e97/include/aws/http/proxy.h:310:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/bd33d9c370c77e08f2b316b8fe32d1d4f63c7e97/include/aws/http/proxy.h:310:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bd33d9c370c77e08f2b316b8fe32d1d4f63c7e97/include/aws/http/proxy.h:310:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/aebb923eb82bc5190f95ab05d8dcc8f5637ae9bf/include/aws/http/proxy.h:304:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bd33d9c370c77e08f2b316b8fe32d1d4f63c7e97/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1241,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/aebb923eb82bc5190f95ab05d8dcc8f5637ae9bf/include/aws/http/proxy.h:304:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bd33d9c370c77e08f2b316b8fe32d1d4f63c7e97/include/aws/http/proxy.h:310:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -185,6 +185,7 @@ struct aws_http_proxy_options
     auth_type::aws_http_proxy_authentication_type
     auth_username::aws_byte_cursor
     auth_password::aws_byte_cursor
+    no_proxy_hosts::aws_byte_cursor
 end
 
 """
@@ -1203,28 +1204,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/d893b03dcc725a2e6cb6641240fe9a80345ebe4c/include/aws/http/proxy.h:304:5)
+    union (unnamed at /home/runner/.julia/artifacts/abf75db7c4a91c83a9b19af73f922b55e606d317/include/aws/http/proxy.h:310:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/d893b03dcc725a2e6cb6641240fe9a80345ebe4c/include/aws/http/proxy.h:304:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/abf75db7c4a91c83a9b19af73f922b55e606d317/include/aws/http/proxy.h:310:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d893b03dcc725a2e6cb6641240fe9a80345ebe4c/include/aws/http/proxy.h:304:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/abf75db7c4a91c83a9b19af73f922b55e606d317/include/aws/http/proxy.h:310:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/d893b03dcc725a2e6cb6641240fe9a80345ebe4c/include/aws/http/proxy.h:304:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/d893b03dcc725a2e6cb6641240fe9a80345ebe4c/include/aws/http/proxy.h:304:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d893b03dcc725a2e6cb6641240fe9a80345ebe4c/include/aws/http/proxy.h:304:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/abf75db7c4a91c83a9b19af73f922b55e606d317/include/aws/http/proxy.h:310:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/abf75db7c4a91c83a9b19af73f922b55e606d317/include/aws/http/proxy.h:310:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/abf75db7c4a91c83a9b19af73f922b55e606d317/include/aws/http/proxy.h:310:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d893b03dcc725a2e6cb6641240fe9a80345ebe4c/include/aws/http/proxy.h:304:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/abf75db7c4a91c83a9b19af73f922b55e606d317/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1241,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d893b03dcc725a2e6cb6641240fe9a80345ebe4c/include/aws/http/proxy.h:304:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/abf75db7c4a91c83a9b19af73f922b55e606d317/include/aws/http/proxy.h:310:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/x86_64-unknown-freebsd13.2.jl
+++ b/lib/x86_64-unknown-freebsd13.2.jl
@@ -185,6 +185,7 @@ struct aws_http_proxy_options
     auth_type::aws_http_proxy_authentication_type
     auth_username::aws_byte_cursor
     auth_password::aws_byte_cursor
+    no_proxy_hosts::aws_byte_cursor
 end
 
 """
@@ -1203,28 +1204,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/b6d7440da36d72b158c0f4b4dcc81c64f0d43ad1/include/aws/http/proxy.h:304:5)
+    union (unnamed at /home/runner/.julia/artifacts/052d647242f780509d346f7f284300ff03923dc7/include/aws/http/proxy.h:310:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/b6d7440da36d72b158c0f4b4dcc81c64f0d43ad1/include/aws/http/proxy.h:304:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/052d647242f780509d346f7f284300ff03923dc7/include/aws/http/proxy.h:310:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b6d7440da36d72b158c0f4b4dcc81c64f0d43ad1/include/aws/http/proxy.h:304:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/052d647242f780509d346f7f284300ff03923dc7/include/aws/http/proxy.h:310:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/b6d7440da36d72b158c0f4b4dcc81c64f0d43ad1/include/aws/http/proxy.h:304:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/b6d7440da36d72b158c0f4b4dcc81c64f0d43ad1/include/aws/http/proxy.h:304:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b6d7440da36d72b158c0f4b4dcc81c64f0d43ad1/include/aws/http/proxy.h:304:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/052d647242f780509d346f7f284300ff03923dc7/include/aws/http/proxy.h:310:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/052d647242f780509d346f7f284300ff03923dc7/include/aws/http/proxy.h:310:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/052d647242f780509d346f7f284300ff03923dc7/include/aws/http/proxy.h:310:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b6d7440da36d72b158c0f4b4dcc81c64f0d43ad1/include/aws/http/proxy.h:304:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/052d647242f780509d346f7f284300ff03923dc7/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1241,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b6d7440da36d72b158c0f4b4dcc81c64f0d43ad1/include/aws/http/proxy.h:304:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/052d647242f780509d346f7f284300ff03923dc7/include/aws/http/proxy.h:310:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -185,6 +185,7 @@ struct aws_http_proxy_options
     auth_type::aws_http_proxy_authentication_type
     auth_username::aws_byte_cursor
     auth_password::aws_byte_cursor
+    no_proxy_hosts::aws_byte_cursor
 end
 
 """
@@ -1203,28 +1204,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/6a7e6ff6fe9495625e928adb6f322cef8b38cf07/include/aws/http/proxy.h:304:5)
+    union (unnamed at /home/runner/.julia/artifacts/d438d6f9e90b8ff9e58afa3daf0d45d30104ea10/include/aws/http/proxy.h:310:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/6a7e6ff6fe9495625e928adb6f322cef8b38cf07/include/aws/http/proxy.h:304:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/d438d6f9e90b8ff9e58afa3daf0d45d30104ea10/include/aws/http/proxy.h:310:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6a7e6ff6fe9495625e928adb6f322cef8b38cf07/include/aws/http/proxy.h:304:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d438d6f9e90b8ff9e58afa3daf0d45d30104ea10/include/aws/http/proxy.h:310:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/6a7e6ff6fe9495625e928adb6f322cef8b38cf07/include/aws/http/proxy.h:304:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/6a7e6ff6fe9495625e928adb6f322cef8b38cf07/include/aws/http/proxy.h:304:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6a7e6ff6fe9495625e928adb6f322cef8b38cf07/include/aws/http/proxy.h:304:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/d438d6f9e90b8ff9e58afa3daf0d45d30104ea10/include/aws/http/proxy.h:310:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/d438d6f9e90b8ff9e58afa3daf0d45d30104ea10/include/aws/http/proxy.h:310:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d438d6f9e90b8ff9e58afa3daf0d45d30104ea10/include/aws/http/proxy.h:310:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6a7e6ff6fe9495625e928adb6f322cef8b38cf07/include/aws/http/proxy.h:304:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d438d6f9e90b8ff9e58afa3daf0d45d30104ea10/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1240,7 +1241,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6a7e6ff6fe9495625e928adb6f322cef8b38cf07/include/aws/http/proxy.h:304:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d438d6f9e90b8ff9e58afa3daf0d45d30104ea10/include/aws/http/proxy.h:310:5)"}(x + 32)
     return getfield(x, f)
 end
 


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_http_jll** to version **0.10.6**
- Updated **JuliaServices/LibAwsHTTP.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings