### PR TITLE
Update aws_c_http_jll to version 0.10.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsHTTP"
 uuid = "ce851869-0d7a-41e7-95ef-2d4cb63876dd"
-version = "1.2.8"
+version = "1.2.9"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -17,7 +17,7 @@ LibAwsCal = "1.1"
 LibAwsCommon = "1.2"
 LibAwsCompression = "1.1"
 LibAwsIO = "1.2"
-aws_c_http_jll = "=0.10.6"
+aws_c_http_jll = "=0.10.7"
 julia = "1.6"
 Test = "1.9"
 

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -14,4 +14,4 @@ aws_c_io_jll = "13c41daa-f319-5298-b5eb-5754e0170d52"
 [compat]
 Clang = "0.18.3"
 JLLPrefixes = "0.3"
-aws_c_http_jll = "=0.10.6"
+aws_c_http_jll = "=0.10.7"

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -1204,28 +1204,28 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/d438d6f9e90b8ff9e58afa3daf0d45d30104ea10/include/aws/http/proxy.h:310:5)
+    union (unnamed at /home/runner/.julia/artifacts/943e61fe1acbb8c8b700c0a6f63df7c33228de2e/include/aws/http/proxy.h:310:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/d438d6f9e90b8ff9e58afa3daf0d45d30104ea10/include/aws/http/proxy.h:310:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/943e61fe1acbb8c8b700c0a6f63df7c33228de2e/include/aws/http/proxy.h:310:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d438d6f9e90b8ff9e58afa3daf0d45d30104ea10/include/aws/http/proxy.h:310:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/943e61fe1acbb8c8b700c0a6f63df7c33228de2e/include/aws/http/proxy.h:310:5)"}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/d438d6f9e90b8ff9e58afa3daf0d45d30104ea10/include/aws/http/proxy.h:310:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/d438d6f9e90b8ff9e58afa3daf0d45d30104ea10/include/aws/http/proxy.h:310:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d438d6f9e90b8ff9e58afa3daf0d45d30104ea10/include/aws/http/proxy.h:310:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/943e61fe1acbb8c8b700c0a6f63df7c33228de2e/include/aws/http/proxy.h:310:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/943e61fe1acbb8c8b700c0a6f63df7c33228de2e/include/aws/http/proxy.h:310:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/943e61fe1acbb8c8b700c0a6f63df7c33228de2e/include/aws/http/proxy.h:310:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d438d6f9e90b8ff9e58afa3daf0d45d30104ea10/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/943e61fe1acbb8c8b700c0a6f63df7c33228de2e/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1241,7 +1241,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d438d6f9e90b8ff9e58afa3daf0d45d30104ea10/include/aws/http/proxy.h:310:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/943e61fe1acbb8c8b700c0a6f63df7c33228de2e/include/aws/http/proxy.h:310:5)"}(x + 32)
     return getfield(x, f)
 end
 


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_http_jll** to version **0.10.7**
- Updated **JuliaServices/LibAwsHTTP.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings