### PR TITLE
Update aws_c_http_jll to version 0.10.9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsHTTP"
 uuid = "ce851869-0d7a-41e7-95ef-2d4cb63876dd"
-version = "1.2.9"
+version = "1.2.10"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -17,7 +17,7 @@ LibAwsCal = "1.1"
 LibAwsCommon = "1.2"
 LibAwsCompression = "1.1"
 LibAwsIO = "1.2"
-aws_c_http_jll = "=0.10.7"
+aws_c_http_jll = "=0.10.9"
 julia = "1.6"
 Test = "1.9"
 

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -14,4 +14,4 @@ aws_c_io_jll = "13c41daa-f319-5298-b5eb-5754e0170d52"
 [compat]
 Clang = "0.18.3,0.19"
 JLLPrefixes = "0.3,0.4"
-aws_c_http_jll = "=0.10.7"
+aws_c_http_jll = "=0.10.9"

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 # typedef void ( aws_http_on_client_connection_setup_fn ) ( struct aws_http_connection * connection , int error_code , void * user_data )
 """
@@ -869,6 +869,19 @@ function aws_http_library_clean_up()
 end
 
 """
+    aws_http_error_code_is_retryable(error_code)
+
+Documentation not found.
+### Prototype
+```c
+bool aws_http_error_code_is_retryable(int error_code);
+```
+"""
+function aws_http_error_code_is_retryable(error_code)
+    ccall((:aws_http_error_code_is_retryable, libaws_c_http), Bool, (Cint,), error_code)
+end
+
+"""
     aws_http_status_text(status_code)
 
 Returns the description of common status codes. Ex: 404 -> "Not Found" An empty string is returned if the status code is not recognized.
@@ -1204,29 +1217,37 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/6d7603c59a4501a850b45dfc8948a5171cde4b8b/include/aws/http/proxy.h:310:5)
+    __JL_Ctag_38
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/6d7603c59a4501a850b45dfc8948a5171cde4b8b/include/aws/http/proxy.h:310:5)"
+struct __JL_Ctag_38
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6d7603c59a4501a850b45dfc8948a5171cde4b8b/include/aws/http/proxy.h:310:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_38}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/6d7603c59a4501a850b45dfc8948a5171cde4b8b/include/aws/http/proxy.h:310:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/6d7603c59a4501a850b45dfc8948a5171cde4b8b/include/aws/http/proxy.h:310:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6d7603c59a4501a850b45dfc8948a5171cde4b8b/include/aws/http/proxy.h:310:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_38, f::Symbol)
+    r = Ref{__JL_Ctag_38}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_38}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6d7603c59a4501a850b45dfc8948a5171cde4b8b/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_38}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_38, private::Bool = false)
+    (:forwarding_vtable, :tunnelling_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1241,7 +1262,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6d7603c59a4501a850b45dfc8948a5171cde4b8b/include/aws/http/proxy.h:310:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{__JL_Ctag_38}(x + 32)
     return getfield(x, f)
 end
 
@@ -1254,6 +1275,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_http_proxy_negotiator}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_http_proxy_negotiator, private::Bool = false)
+    (:ref_count, :impl, :strategy_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -2442,14 +2471,15 @@ function aws_http_message_set_body_stream(message, body_stream)
 end
 
 """
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
 """
 mutable struct aws_future_http_message end
 
 """
     aws_future_http_message_new(alloc)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2462,7 +2492,8 @@ end
 """
     aws_future_http_message_set_result_by_move(future, pointer_address)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2475,7 +2506,8 @@ end
 """
     aws_future_http_message_get_result_by_move(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2488,7 +2520,8 @@ end
 """
     aws_future_http_message_peek_result(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2501,7 +2534,8 @@ end
 """
     aws_future_http_message_acquire(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2514,7 +2548,8 @@ end
 """
     aws_future_http_message_release(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2527,7 +2562,8 @@ end
 """
     aws_future_http_message_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2540,7 +2576,8 @@ end
 """
     aws_future_http_message_is_done(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2553,7 +2590,8 @@ end
 """
     aws_future_http_message_get_error(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2566,7 +2604,8 @@ end
 """
     aws_future_http_message_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2579,7 +2618,8 @@ end
 """
     aws_future_http_message_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2592,7 +2632,8 @@ end
 """
     aws_future_http_message_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2605,7 +2646,8 @@ end
 """
     aws_future_http_message_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2618,7 +2660,8 @@ end
 """
     aws_future_http_message_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 # typedef void ( aws_http_on_client_connection_setup_fn ) ( struct aws_http_connection * connection , int error_code , void * user_data )
 """
@@ -869,6 +869,19 @@ function aws_http_library_clean_up()
 end
 
 """
+    aws_http_error_code_is_retryable(error_code)
+
+Documentation not found.
+### Prototype
+```c
+bool aws_http_error_code_is_retryable(int error_code);
+```
+"""
+function aws_http_error_code_is_retryable(error_code)
+    ccall((:aws_http_error_code_is_retryable, libaws_c_http), Bool, (Cint,), error_code)
+end
+
+"""
     aws_http_status_text(status_code)
 
 Returns the description of common status codes. Ex: 404 -> "Not Found" An empty string is returned if the status code is not recognized.
@@ -1204,32 +1217,6 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/037c3a29e2d275d5226a1ad23da6c2b531790198/include/aws/http/proxy.h:310:5)
-
-Documentation not found.
-"""
-struct var"union (unnamed at /home/runner/.julia/artifacts/037c3a29e2d275d5226a1ad23da6c2b531790198/include/aws/http/proxy.h:310:5)"
-    data::NTuple{8, UInt8}
-end
-
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/037c3a29e2d275d5226a1ad23da6c2b531790198/include/aws/http/proxy.h:310:5)"}, f::Symbol)
-    f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
-    f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
-    return getfield(x, f)
-end
-
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/037c3a29e2d275d5226a1ad23da6c2b531790198/include/aws/http/proxy.h:310:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/037c3a29e2d275d5226a1ad23da6c2b531790198/include/aws/http/proxy.h:310:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/037c3a29e2d275d5226a1ad23da6c2b531790198/include/aws/http/proxy.h:310:5)"}, r)
-    fptr = getproperty(ptr, f)
-    GC.@preserve r unsafe_load(fptr)
-end
-
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/037c3a29e2d275d5226a1ad23da6c2b531790198/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
-    unsafe_store!(getproperty(x, f), v)
-end
-
-"""
     aws_http_proxy_negotiator
 
 Documentation not found.
@@ -1241,7 +1228,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/037c3a29e2d275d5226a1ad23da6c2b531790198/include/aws/http/proxy.h:310:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{__JL_Ctag_182}(x + 32)
     return getfield(x, f)
 end
 
@@ -1254,6 +1241,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_http_proxy_negotiator}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_http_proxy_negotiator, private::Bool = false)
+    (:ref_count, :impl, :strategy_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -2442,14 +2437,15 @@ function aws_http_message_set_body_stream(message, body_stream)
 end
 
 """
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
 """
 mutable struct aws_future_http_message end
 
 """
     aws_future_http_message_new(alloc)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2462,7 +2458,8 @@ end
 """
     aws_future_http_message_set_result_by_move(future, pointer_address)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2475,7 +2472,8 @@ end
 """
     aws_future_http_message_get_result_by_move(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2488,7 +2486,8 @@ end
 """
     aws_future_http_message_peek_result(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2501,7 +2500,8 @@ end
 """
     aws_future_http_message_acquire(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2514,7 +2514,8 @@ end
 """
     aws_future_http_message_release(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2527,7 +2528,8 @@ end
 """
     aws_future_http_message_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2540,7 +2542,8 @@ end
 """
     aws_future_http_message_is_done(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2553,7 +2556,8 @@ end
 """
     aws_future_http_message_get_error(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2566,7 +2570,8 @@ end
 """
     aws_future_http_message_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2579,7 +2584,8 @@ end
 """
     aws_future_http_message_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2592,7 +2598,8 @@ end
 """
     aws_future_http_message_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2605,7 +2612,8 @@ end
 """
     aws_future_http_message_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2618,7 +2626,8 @@ end
 """
     aws_future_http_message_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 # typedef void ( aws_http_on_client_connection_setup_fn ) ( struct aws_http_connection * connection , int error_code , void * user_data )
 """
@@ -869,6 +869,19 @@ function aws_http_library_clean_up()
 end
 
 """
+    aws_http_error_code_is_retryable(error_code)
+
+Documentation not found.
+### Prototype
+```c
+bool aws_http_error_code_is_retryable(int error_code);
+```
+"""
+function aws_http_error_code_is_retryable(error_code)
+    ccall((:aws_http_error_code_is_retryable, libaws_c_http), Bool, (Cint,), error_code)
+end
+
+"""
     aws_http_status_text(status_code)
 
 Returns the description of common status codes. Ex: 404 -> "Not Found" An empty string is returned if the status code is not recognized.
@@ -1204,29 +1217,37 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/d8ccc286a06e70394bd760e19fc84a36e51c3dc5/include/aws/http/proxy.h:310:5)
+    __JL_Ctag_29
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/d8ccc286a06e70394bd760e19fc84a36e51c3dc5/include/aws/http/proxy.h:310:5)"
+struct __JL_Ctag_29
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d8ccc286a06e70394bd760e19fc84a36e51c3dc5/include/aws/http/proxy.h:310:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_29}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/d8ccc286a06e70394bd760e19fc84a36e51c3dc5/include/aws/http/proxy.h:310:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/d8ccc286a06e70394bd760e19fc84a36e51c3dc5/include/aws/http/proxy.h:310:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d8ccc286a06e70394bd760e19fc84a36e51c3dc5/include/aws/http/proxy.h:310:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_29, f::Symbol)
+    r = Ref{__JL_Ctag_29}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_29}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d8ccc286a06e70394bd760e19fc84a36e51c3dc5/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_29}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_29, private::Bool = false)
+    (:forwarding_vtable, :tunnelling_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1241,7 +1262,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d8ccc286a06e70394bd760e19fc84a36e51c3dc5/include/aws/http/proxy.h:310:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{__JL_Ctag_29}(x + 32)
     return getfield(x, f)
 end
 
@@ -1254,6 +1275,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_http_proxy_negotiator}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_http_proxy_negotiator, private::Bool = false)
+    (:ref_count, :impl, :strategy_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -2442,14 +2471,15 @@ function aws_http_message_set_body_stream(message, body_stream)
 end
 
 """
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
 """
 mutable struct aws_future_http_message end
 
 """
     aws_future_http_message_new(alloc)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2462,7 +2492,8 @@ end
 """
     aws_future_http_message_set_result_by_move(future, pointer_address)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2475,7 +2506,8 @@ end
 """
     aws_future_http_message_get_result_by_move(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2488,7 +2520,8 @@ end
 """
     aws_future_http_message_peek_result(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2501,7 +2534,8 @@ end
 """
     aws_future_http_message_acquire(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2514,7 +2548,8 @@ end
 """
     aws_future_http_message_release(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2527,7 +2562,8 @@ end
 """
     aws_future_http_message_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2540,7 +2576,8 @@ end
 """
     aws_future_http_message_is_done(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2553,7 +2590,8 @@ end
 """
     aws_future_http_message_get_error(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2566,7 +2604,8 @@ end
 """
     aws_future_http_message_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2579,7 +2618,8 @@ end
 """
     aws_future_http_message_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2592,7 +2632,8 @@ end
 """
     aws_future_http_message_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2605,7 +2646,8 @@ end
 """
     aws_future_http_message_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2618,7 +2660,8 @@ end
 """
     aws_future_http_message_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 # typedef void ( aws_http_on_client_connection_setup_fn ) ( struct aws_http_connection * connection , int error_code , void * user_data )
 """
@@ -869,6 +869,19 @@ function aws_http_library_clean_up()
 end
 
 """
+    aws_http_error_code_is_retryable(error_code)
+
+Documentation not found.
+### Prototype
+```c
+bool aws_http_error_code_is_retryable(int error_code);
+```
+"""
+function aws_http_error_code_is_retryable(error_code)
+    ccall((:aws_http_error_code_is_retryable, libaws_c_http), Bool, (Cint,), error_code)
+end
+
+"""
     aws_http_status_text(status_code)
 
 Returns the description of common status codes. Ex: 404 -> "Not Found" An empty string is returned if the status code is not recognized.
@@ -1204,32 +1217,6 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/699ec37bac8353debf4eb48cdd7d868362ca767b/include/aws/http/proxy.h:310:5)
-
-Documentation not found.
-"""
-struct var"union (unnamed at /home/runner/.julia/artifacts/699ec37bac8353debf4eb48cdd7d868362ca767b/include/aws/http/proxy.h:310:5)"
-    data::NTuple{4, UInt8}
-end
-
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/699ec37bac8353debf4eb48cdd7d868362ca767b/include/aws/http/proxy.h:310:5)"}, f::Symbol)
-    f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
-    f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
-    return getfield(x, f)
-end
-
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/699ec37bac8353debf4eb48cdd7d868362ca767b/include/aws/http/proxy.h:310:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/699ec37bac8353debf4eb48cdd7d868362ca767b/include/aws/http/proxy.h:310:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/699ec37bac8353debf4eb48cdd7d868362ca767b/include/aws/http/proxy.h:310:5)"}, r)
-    fptr = getproperty(ptr, f)
-    GC.@preserve r unsafe_load(fptr)
-end
-
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/699ec37bac8353debf4eb48cdd7d868362ca767b/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
-    unsafe_store!(getproperty(x, f), v)
-end
-
-"""
     aws_http_proxy_negotiator
 
 Documentation not found.
@@ -1241,7 +1228,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/699ec37bac8353debf4eb48cdd7d868362ca767b/include/aws/http/proxy.h:310:5)"}(x + 16)
+    f === :strategy_vtable && return Ptr{__JL_Ctag_182}(x + 16)
     return getfield(x, f)
 end
 
@@ -1254,6 +1241,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_http_proxy_negotiator}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_http_proxy_negotiator, private::Bool = false)
+    (:ref_count, :impl, :strategy_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -2442,14 +2437,15 @@ function aws_http_message_set_body_stream(message, body_stream)
 end
 
 """
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
 """
 mutable struct aws_future_http_message end
 
 """
     aws_future_http_message_new(alloc)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2462,7 +2458,8 @@ end
 """
     aws_future_http_message_set_result_by_move(future, pointer_address)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2475,7 +2472,8 @@ end
 """
     aws_future_http_message_get_result_by_move(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2488,7 +2486,8 @@ end
 """
     aws_future_http_message_peek_result(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2501,7 +2500,8 @@ end
 """
     aws_future_http_message_acquire(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2514,7 +2514,8 @@ end
 """
     aws_future_http_message_release(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2527,7 +2528,8 @@ end
 """
     aws_future_http_message_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2540,7 +2542,8 @@ end
 """
     aws_future_http_message_is_done(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2553,7 +2556,8 @@ end
 """
     aws_future_http_message_get_error(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2566,7 +2570,8 @@ end
 """
     aws_future_http_message_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2579,7 +2584,8 @@ end
 """
     aws_future_http_message_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2592,7 +2598,8 @@ end
 """
     aws_future_http_message_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2605,7 +2612,8 @@ end
 """
     aws_future_http_message_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2618,7 +2626,8 @@ end
 """
     aws_future_http_message_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 # typedef void ( aws_http_on_client_connection_setup_fn ) ( struct aws_http_connection * connection , int error_code , void * user_data )
 """
@@ -869,6 +869,19 @@ function aws_http_library_clean_up()
 end
 
 """
+    aws_http_error_code_is_retryable(error_code)
+
+Documentation not found.
+### Prototype
+```c
+bool aws_http_error_code_is_retryable(int error_code);
+```
+"""
+function aws_http_error_code_is_retryable(error_code)
+    ccall((:aws_http_error_code_is_retryable, libaws_c_http), Bool, (Cint,), error_code)
+end
+
+"""
     aws_http_status_text(status_code)
 
 Returns the description of common status codes. Ex: 404 -> "Not Found" An empty string is returned if the status code is not recognized.
@@ -1204,29 +1217,37 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/bf9aa186eb1d6ad60c818a68e4e052adf03e5aed/include/aws/http/proxy.h:310:5)
+    __JL_Ctag_29
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/bf9aa186eb1d6ad60c818a68e4e052adf03e5aed/include/aws/http/proxy.h:310:5)"
+struct __JL_Ctag_29
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bf9aa186eb1d6ad60c818a68e4e052adf03e5aed/include/aws/http/proxy.h:310:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_29}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/bf9aa186eb1d6ad60c818a68e4e052adf03e5aed/include/aws/http/proxy.h:310:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/bf9aa186eb1d6ad60c818a68e4e052adf03e5aed/include/aws/http/proxy.h:310:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bf9aa186eb1d6ad60c818a68e4e052adf03e5aed/include/aws/http/proxy.h:310:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_29, f::Symbol)
+    r = Ref{__JL_Ctag_29}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_29}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bf9aa186eb1d6ad60c818a68e4e052adf03e5aed/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_29}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_29, private::Bool = false)
+    (:forwarding_vtable, :tunnelling_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1241,7 +1262,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bf9aa186eb1d6ad60c818a68e4e052adf03e5aed/include/aws/http/proxy.h:310:5)"}(x + 16)
+    f === :strategy_vtable && return Ptr{__JL_Ctag_29}(x + 16)
     return getfield(x, f)
 end
 
@@ -1254,6 +1275,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_http_proxy_negotiator}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_http_proxy_negotiator, private::Bool = false)
+    (:ref_count, :impl, :strategy_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -2442,14 +2471,15 @@ function aws_http_message_set_body_stream(message, body_stream)
 end
 
 """
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
 """
 mutable struct aws_future_http_message end
 
 """
     aws_future_http_message_new(alloc)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2462,7 +2492,8 @@ end
 """
     aws_future_http_message_set_result_by_move(future, pointer_address)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2475,7 +2506,8 @@ end
 """
     aws_future_http_message_get_result_by_move(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2488,7 +2520,8 @@ end
 """
     aws_future_http_message_peek_result(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2501,7 +2534,8 @@ end
 """
     aws_future_http_message_acquire(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2514,7 +2548,8 @@ end
 """
     aws_future_http_message_release(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2527,7 +2562,8 @@ end
 """
     aws_future_http_message_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2540,7 +2576,8 @@ end
 """
     aws_future_http_message_is_done(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2553,7 +2590,8 @@ end
 """
     aws_future_http_message_get_error(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2566,7 +2604,8 @@ end
 """
     aws_future_http_message_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2579,7 +2618,8 @@ end
 """
     aws_future_http_message_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2592,7 +2632,8 @@ end
 """
     aws_future_http_message_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2605,7 +2646,8 @@ end
 """
     aws_future_http_message_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2618,7 +2660,8 @@ end
 """
     aws_future_http_message_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 # typedef void ( aws_http_on_client_connection_setup_fn ) ( struct aws_http_connection * connection , int error_code , void * user_data )
 """
@@ -869,6 +869,19 @@ function aws_http_library_clean_up()
 end
 
 """
+    aws_http_error_code_is_retryable(error_code)
+
+Documentation not found.
+### Prototype
+```c
+bool aws_http_error_code_is_retryable(int error_code);
+```
+"""
+function aws_http_error_code_is_retryable(error_code)
+    ccall((:aws_http_error_code_is_retryable, libaws_c_http), Bool, (Cint,), error_code)
+end
+
+"""
     aws_http_status_text(status_code)
 
 Returns the description of common status codes. Ex: 404 -> "Not Found" An empty string is returned if the status code is not recognized.
@@ -1204,29 +1217,37 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/c0b899b922cab3e1bad8b88b0c52ce635189e6ad/include/aws/http/proxy.h:310:5)
+    __JL_Ctag_173
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/c0b899b922cab3e1bad8b88b0c52ce635189e6ad/include/aws/http/proxy.h:310:5)"
+struct __JL_Ctag_173
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c0b899b922cab3e1bad8b88b0c52ce635189e6ad/include/aws/http/proxy.h:310:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_173}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/c0b899b922cab3e1bad8b88b0c52ce635189e6ad/include/aws/http/proxy.h:310:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/c0b899b922cab3e1bad8b88b0c52ce635189e6ad/include/aws/http/proxy.h:310:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c0b899b922cab3e1bad8b88b0c52ce635189e6ad/include/aws/http/proxy.h:310:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_173, f::Symbol)
+    r = Ref{__JL_Ctag_173}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_173}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c0b899b922cab3e1bad8b88b0c52ce635189e6ad/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_173}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_173, private::Bool = false)
+    (:forwarding_vtable, :tunnelling_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1241,7 +1262,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c0b899b922cab3e1bad8b88b0c52ce635189e6ad/include/aws/http/proxy.h:310:5)"}(x + 16)
+    f === :strategy_vtable && return Ptr{__JL_Ctag_173}(x + 16)
     return getfield(x, f)
 end
 
@@ -1254,6 +1275,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_http_proxy_negotiator}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_http_proxy_negotiator, private::Bool = false)
+    (:ref_count, :impl, :strategy_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -2442,14 +2471,15 @@ function aws_http_message_set_body_stream(message, body_stream)
 end
 
 """
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
 """
 mutable struct aws_future_http_message end
 
 """
     aws_future_http_message_new(alloc)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2462,7 +2492,8 @@ end
 """
     aws_future_http_message_set_result_by_move(future, pointer_address)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2475,7 +2506,8 @@ end
 """
     aws_future_http_message_get_result_by_move(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2488,7 +2520,8 @@ end
 """
     aws_future_http_message_peek_result(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2501,7 +2534,8 @@ end
 """
     aws_future_http_message_acquire(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2514,7 +2548,8 @@ end
 """
     aws_future_http_message_release(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2527,7 +2562,8 @@ end
 """
     aws_future_http_message_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2540,7 +2576,8 @@ end
 """
     aws_future_http_message_is_done(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2553,7 +2590,8 @@ end
 """
     aws_future_http_message_get_error(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2566,7 +2604,8 @@ end
 """
     aws_future_http_message_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2579,7 +2618,8 @@ end
 """
     aws_future_http_message_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2592,7 +2632,8 @@ end
 """
     aws_future_http_message_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2605,7 +2646,8 @@ end
 """
     aws_future_http_message_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2618,7 +2660,8 @@ end
 """
     aws_future_http_message_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 # typedef void ( aws_http_on_client_connection_setup_fn ) ( struct aws_http_connection * connection , int error_code , void * user_data )
 """
@@ -869,6 +869,19 @@ function aws_http_library_clean_up()
 end
 
 """
+    aws_http_error_code_is_retryable(error_code)
+
+Documentation not found.
+### Prototype
+```c
+bool aws_http_error_code_is_retryable(int error_code);
+```
+"""
+function aws_http_error_code_is_retryable(error_code)
+    ccall((:aws_http_error_code_is_retryable, libaws_c_http), Bool, (Cint,), error_code)
+end
+
+"""
     aws_http_status_text(status_code)
 
 Returns the description of common status codes. Ex: 404 -> "Not Found" An empty string is returned if the status code is not recognized.
@@ -1204,29 +1217,37 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/3c02364f88c462f406cf75cec16399fb74209907/include/aws/http/proxy.h:310:5)
+    __JL_Ctag_29
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/3c02364f88c462f406cf75cec16399fb74209907/include/aws/http/proxy.h:310:5)"
+struct __JL_Ctag_29
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3c02364f88c462f406cf75cec16399fb74209907/include/aws/http/proxy.h:310:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_29}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/3c02364f88c462f406cf75cec16399fb74209907/include/aws/http/proxy.h:310:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/3c02364f88c462f406cf75cec16399fb74209907/include/aws/http/proxy.h:310:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3c02364f88c462f406cf75cec16399fb74209907/include/aws/http/proxy.h:310:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_29, f::Symbol)
+    r = Ref{__JL_Ctag_29}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_29}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3c02364f88c462f406cf75cec16399fb74209907/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_29}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_29, private::Bool = false)
+    (:forwarding_vtable, :tunnelling_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1241,7 +1262,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 12)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3c02364f88c462f406cf75cec16399fb74209907/include/aws/http/proxy.h:310:5)"}(x + 16)
+    f === :strategy_vtable && return Ptr{__JL_Ctag_29}(x + 16)
     return getfield(x, f)
 end
 
@@ -1254,6 +1275,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_http_proxy_negotiator}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_http_proxy_negotiator, private::Bool = false)
+    (:ref_count, :impl, :strategy_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -2442,14 +2471,15 @@ function aws_http_message_set_body_stream(message, body_stream)
 end
 
 """
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
 """
 mutable struct aws_future_http_message end
 
 """
     aws_future_http_message_new(alloc)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2462,7 +2492,8 @@ end
 """
     aws_future_http_message_set_result_by_move(future, pointer_address)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2475,7 +2506,8 @@ end
 """
     aws_future_http_message_get_result_by_move(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2488,7 +2520,8 @@ end
 """
     aws_future_http_message_peek_result(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2501,7 +2534,8 @@ end
 """
     aws_future_http_message_acquire(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2514,7 +2548,8 @@ end
 """
     aws_future_http_message_release(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2527,7 +2562,8 @@ end
 """
     aws_future_http_message_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2540,7 +2576,8 @@ end
 """
     aws_future_http_message_is_done(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2553,7 +2590,8 @@ end
 """
     aws_future_http_message_get_error(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2566,7 +2604,8 @@ end
 """
     aws_future_http_message_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2579,7 +2618,8 @@ end
 """
     aws_future_http_message_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2592,7 +2632,8 @@ end
 """
     aws_future_http_message_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2605,7 +2646,8 @@ end
 """
     aws_future_http_message_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2618,7 +2660,8 @@ end
 """
     aws_future_http_message_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 # typedef void ( aws_http_on_client_connection_setup_fn ) ( struct aws_http_connection * connection , int error_code , void * user_data )
 """
@@ -869,6 +869,19 @@ function aws_http_library_clean_up()
 end
 
 """
+    aws_http_error_code_is_retryable(error_code)
+
+Documentation not found.
+### Prototype
+```c
+bool aws_http_error_code_is_retryable(int error_code);
+```
+"""
+function aws_http_error_code_is_retryable(error_code)
+    ccall((:aws_http_error_code_is_retryable, libaws_c_http), Bool, (Cint,), error_code)
+end
+
+"""
     aws_http_status_text(status_code)
 
 Returns the description of common status codes. Ex: 404 -> "Not Found" An empty string is returned if the status code is not recognized.
@@ -1204,29 +1217,37 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/d4f342fa90cfeba5f2201a7e3875e80659ca0bfe/include/aws/http/proxy.h:310:5)
+    __JL_Ctag_173
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/d4f342fa90cfeba5f2201a7e3875e80659ca0bfe/include/aws/http/proxy.h:310:5)"
+struct __JL_Ctag_173
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d4f342fa90cfeba5f2201a7e3875e80659ca0bfe/include/aws/http/proxy.h:310:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_173}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/d4f342fa90cfeba5f2201a7e3875e80659ca0bfe/include/aws/http/proxy.h:310:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/d4f342fa90cfeba5f2201a7e3875e80659ca0bfe/include/aws/http/proxy.h:310:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d4f342fa90cfeba5f2201a7e3875e80659ca0bfe/include/aws/http/proxy.h:310:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_173, f::Symbol)
+    r = Ref{__JL_Ctag_173}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_173}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d4f342fa90cfeba5f2201a7e3875e80659ca0bfe/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_173}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_173, private::Bool = false)
+    (:forwarding_vtable, :tunnelling_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1241,7 +1262,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d4f342fa90cfeba5f2201a7e3875e80659ca0bfe/include/aws/http/proxy.h:310:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{__JL_Ctag_173}(x + 32)
     return getfield(x, f)
 end
 
@@ -1254,6 +1275,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_http_proxy_negotiator}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_http_proxy_negotiator, private::Bool = false)
+    (:ref_count, :impl, :strategy_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -2442,14 +2471,15 @@ function aws_http_message_set_body_stream(message, body_stream)
 end
 
 """
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
 """
 mutable struct aws_future_http_message end
 
 """
     aws_future_http_message_new(alloc)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2462,7 +2492,8 @@ end
 """
     aws_future_http_message_set_result_by_move(future, pointer_address)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2475,7 +2506,8 @@ end
 """
     aws_future_http_message_get_result_by_move(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2488,7 +2520,8 @@ end
 """
     aws_future_http_message_peek_result(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2501,7 +2534,8 @@ end
 """
     aws_future_http_message_acquire(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2514,7 +2548,8 @@ end
 """
     aws_future_http_message_release(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2527,7 +2562,8 @@ end
 """
     aws_future_http_message_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2540,7 +2576,8 @@ end
 """
     aws_future_http_message_is_done(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2553,7 +2590,8 @@ end
 """
     aws_future_http_message_get_error(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2566,7 +2604,8 @@ end
 """
     aws_future_http_message_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2579,7 +2618,8 @@ end
 """
     aws_future_http_message_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2592,7 +2632,8 @@ end
 """
     aws_future_http_message_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2605,7 +2646,8 @@ end
 """
     aws_future_http_message_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2618,7 +2660,8 @@ end
 """
     aws_future_http_message_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 # typedef void ( aws_http_on_client_connection_setup_fn ) ( struct aws_http_connection * connection , int error_code , void * user_data )
 """
@@ -869,6 +869,19 @@ function aws_http_library_clean_up()
 end
 
 """
+    aws_http_error_code_is_retryable(error_code)
+
+Documentation not found.
+### Prototype
+```c
+bool aws_http_error_code_is_retryable(int error_code);
+```
+"""
+function aws_http_error_code_is_retryable(error_code)
+    ccall((:aws_http_error_code_is_retryable, libaws_c_http), Bool, (Cint,), error_code)
+end
+
+"""
     aws_http_status_text(status_code)
 
 Returns the description of common status codes. Ex: 404 -> "Not Found" An empty string is returned if the status code is not recognized.
@@ -1204,29 +1217,37 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/bb083fc2d9c8ad49a33dce760f0771407ee9f35a/include/aws/http/proxy.h:310:5)
+    __JL_Ctag_38
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/bb083fc2d9c8ad49a33dce760f0771407ee9f35a/include/aws/http/proxy.h:310:5)"
+struct __JL_Ctag_38
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bb083fc2d9c8ad49a33dce760f0771407ee9f35a/include/aws/http/proxy.h:310:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_38}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/bb083fc2d9c8ad49a33dce760f0771407ee9f35a/include/aws/http/proxy.h:310:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/bb083fc2d9c8ad49a33dce760f0771407ee9f35a/include/aws/http/proxy.h:310:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bb083fc2d9c8ad49a33dce760f0771407ee9f35a/include/aws/http/proxy.h:310:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_38, f::Symbol)
+    r = Ref{__JL_Ctag_38}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_38}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bb083fc2d9c8ad49a33dce760f0771407ee9f35a/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_38}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_38, private::Bool = false)
+    (:forwarding_vtable, :tunnelling_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1241,7 +1262,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bb083fc2d9c8ad49a33dce760f0771407ee9f35a/include/aws/http/proxy.h:310:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{__JL_Ctag_38}(x + 32)
     return getfield(x, f)
 end
 
@@ -1254,6 +1275,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_http_proxy_negotiator}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_http_proxy_negotiator, private::Bool = false)
+    (:ref_count, :impl, :strategy_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -2442,14 +2471,15 @@ function aws_http_message_set_body_stream(message, body_stream)
 end
 
 """
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
 """
 mutable struct aws_future_http_message end
 
 """
     aws_future_http_message_new(alloc)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2462,7 +2492,8 @@ end
 """
     aws_future_http_message_set_result_by_move(future, pointer_address)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2475,7 +2506,8 @@ end
 """
     aws_future_http_message_get_result_by_move(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2488,7 +2520,8 @@ end
 """
     aws_future_http_message_peek_result(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2501,7 +2534,8 @@ end
 """
     aws_future_http_message_acquire(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2514,7 +2548,8 @@ end
 """
     aws_future_http_message_release(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2527,7 +2562,8 @@ end
 """
     aws_future_http_message_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2540,7 +2576,8 @@ end
 """
     aws_future_http_message_is_done(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2553,7 +2590,8 @@ end
 """
     aws_future_http_message_get_error(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2566,7 +2604,8 @@ end
 """
     aws_future_http_message_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2579,7 +2618,8 @@ end
 """
     aws_future_http_message_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2592,7 +2632,8 @@ end
 """
     aws_future_http_message_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2605,7 +2646,8 @@ end
 """
     aws_future_http_message_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2618,7 +2660,8 @@ end
 """
     aws_future_http_message_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 # typedef void ( aws_http_on_client_connection_setup_fn ) ( struct aws_http_connection * connection , int error_code , void * user_data )
 """
@@ -869,6 +869,19 @@ function aws_http_library_clean_up()
 end
 
 """
+    aws_http_error_code_is_retryable(error_code)
+
+Documentation not found.
+### Prototype
+```c
+bool aws_http_error_code_is_retryable(int error_code);
+```
+"""
+function aws_http_error_code_is_retryable(error_code)
+    ccall((:aws_http_error_code_is_retryable, libaws_c_http), Bool, (Cint,), error_code)
+end
+
+"""
     aws_http_status_text(status_code)
 
 Returns the description of common status codes. Ex: 404 -> "Not Found" An empty string is returned if the status code is not recognized.
@@ -1204,29 +1217,37 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/bd33d9c370c77e08f2b316b8fe32d1d4f63c7e97/include/aws/http/proxy.h:310:5)
+    __JL_Ctag_164
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/bd33d9c370c77e08f2b316b8fe32d1d4f63c7e97/include/aws/http/proxy.h:310:5)"
+struct __JL_Ctag_164
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bd33d9c370c77e08f2b316b8fe32d1d4f63c7e97/include/aws/http/proxy.h:310:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_164}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/bd33d9c370c77e08f2b316b8fe32d1d4f63c7e97/include/aws/http/proxy.h:310:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/bd33d9c370c77e08f2b316b8fe32d1d4f63c7e97/include/aws/http/proxy.h:310:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bd33d9c370c77e08f2b316b8fe32d1d4f63c7e97/include/aws/http/proxy.h:310:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_164, f::Symbol)
+    r = Ref{__JL_Ctag_164}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_164}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bd33d9c370c77e08f2b316b8fe32d1d4f63c7e97/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_164}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_164, private::Bool = false)
+    (:forwarding_vtable, :tunnelling_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1241,7 +1262,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bd33d9c370c77e08f2b316b8fe32d1d4f63c7e97/include/aws/http/proxy.h:310:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{__JL_Ctag_164}(x + 32)
     return getfield(x, f)
 end
 
@@ -1254,6 +1275,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_http_proxy_negotiator}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_http_proxy_negotiator, private::Bool = false)
+    (:ref_count, :impl, :strategy_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -2442,14 +2471,15 @@ function aws_http_message_set_body_stream(message, body_stream)
 end
 
 """
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
 """
 mutable struct aws_future_http_message end
 
 """
     aws_future_http_message_new(alloc)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2462,7 +2492,8 @@ end
 """
     aws_future_http_message_set_result_by_move(future, pointer_address)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2475,7 +2506,8 @@ end
 """
     aws_future_http_message_get_result_by_move(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2488,7 +2520,8 @@ end
 """
     aws_future_http_message_peek_result(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2501,7 +2534,8 @@ end
 """
     aws_future_http_message_acquire(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2514,7 +2548,8 @@ end
 """
     aws_future_http_message_release(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2527,7 +2562,8 @@ end
 """
     aws_future_http_message_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2540,7 +2576,8 @@ end
 """
     aws_future_http_message_is_done(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2553,7 +2590,8 @@ end
 """
     aws_future_http_message_get_error(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2566,7 +2604,8 @@ end
 """
     aws_future_http_message_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2579,7 +2618,8 @@ end
 """
     aws_future_http_message_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2592,7 +2632,8 @@ end
 """
     aws_future_http_message_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2605,7 +2646,8 @@ end
 """
     aws_future_http_message_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2618,7 +2660,8 @@ end
 """
     aws_future_http_message_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 # typedef void ( aws_http_on_client_connection_setup_fn ) ( struct aws_http_connection * connection , int error_code , void * user_data )
 """
@@ -869,6 +869,19 @@ function aws_http_library_clean_up()
 end
 
 """
+    aws_http_error_code_is_retryable(error_code)
+
+Documentation not found.
+### Prototype
+```c
+bool aws_http_error_code_is_retryable(int error_code);
+```
+"""
+function aws_http_error_code_is_retryable(error_code)
+    ccall((:aws_http_error_code_is_retryable, libaws_c_http), Bool, (Cint,), error_code)
+end
+
+"""
     aws_http_status_text(status_code)
 
 Returns the description of common status codes. Ex: 404 -> "Not Found" An empty string is returned if the status code is not recognized.
@@ -1204,29 +1217,37 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/abf75db7c4a91c83a9b19af73f922b55e606d317/include/aws/http/proxy.h:310:5)
+    __JL_Ctag_29
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/abf75db7c4a91c83a9b19af73f922b55e606d317/include/aws/http/proxy.h:310:5)"
+struct __JL_Ctag_29
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/abf75db7c4a91c83a9b19af73f922b55e606d317/include/aws/http/proxy.h:310:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_29}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/abf75db7c4a91c83a9b19af73f922b55e606d317/include/aws/http/proxy.h:310:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/abf75db7c4a91c83a9b19af73f922b55e606d317/include/aws/http/proxy.h:310:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/abf75db7c4a91c83a9b19af73f922b55e606d317/include/aws/http/proxy.h:310:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_29, f::Symbol)
+    r = Ref{__JL_Ctag_29}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_29}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/abf75db7c4a91c83a9b19af73f922b55e606d317/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_29}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_29, private::Bool = false)
+    (:forwarding_vtable, :tunnelling_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1241,7 +1262,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/abf75db7c4a91c83a9b19af73f922b55e606d317/include/aws/http/proxy.h:310:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{__JL_Ctag_29}(x + 32)
     return getfield(x, f)
 end
 
@@ -1254,6 +1275,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_http_proxy_negotiator}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_http_proxy_negotiator, private::Bool = false)
+    (:ref_count, :impl, :strategy_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -2442,14 +2471,15 @@ function aws_http_message_set_body_stream(message, body_stream)
 end
 
 """
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
 """
 mutable struct aws_future_http_message end
 
 """
     aws_future_http_message_new(alloc)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2462,7 +2492,8 @@ end
 """
     aws_future_http_message_set_result_by_move(future, pointer_address)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2475,7 +2506,8 @@ end
 """
     aws_future_http_message_get_result_by_move(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2488,7 +2520,8 @@ end
 """
     aws_future_http_message_peek_result(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2501,7 +2534,8 @@ end
 """
     aws_future_http_message_acquire(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2514,7 +2548,8 @@ end
 """
     aws_future_http_message_release(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2527,7 +2562,8 @@ end
 """
     aws_future_http_message_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2540,7 +2576,8 @@ end
 """
     aws_future_http_message_is_done(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2553,7 +2590,8 @@ end
 """
     aws_future_http_message_get_error(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2566,7 +2604,8 @@ end
 """
     aws_future_http_message_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2579,7 +2618,8 @@ end
 """
     aws_future_http_message_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2592,7 +2632,8 @@ end
 """
     aws_future_http_message_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2605,7 +2646,8 @@ end
 """
     aws_future_http_message_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2618,7 +2660,8 @@ end
 """
     aws_future_http_message_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);

--- a/lib/x86_64-unknown-freebsd13.2.jl
+++ b/lib/x86_64-unknown-freebsd13.2.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 # typedef void ( aws_http_on_client_connection_setup_fn ) ( struct aws_http_connection * connection , int error_code , void * user_data )
 """
@@ -869,6 +869,19 @@ function aws_http_library_clean_up()
 end
 
 """
+    aws_http_error_code_is_retryable(error_code)
+
+Documentation not found.
+### Prototype
+```c
+bool aws_http_error_code_is_retryable(int error_code);
+```
+"""
+function aws_http_error_code_is_retryable(error_code)
+    ccall((:aws_http_error_code_is_retryable, libaws_c_http), Bool, (Cint,), error_code)
+end
+
+"""
     aws_http_status_text(status_code)
 
 Returns the description of common status codes. Ex: 404 -> "Not Found" An empty string is returned if the status code is not recognized.
@@ -1204,29 +1217,37 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/052d647242f780509d346f7f284300ff03923dc7/include/aws/http/proxy.h:310:5)
+    __JL_Ctag_29
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/052d647242f780509d346f7f284300ff03923dc7/include/aws/http/proxy.h:310:5)"
+struct __JL_Ctag_29
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/052d647242f780509d346f7f284300ff03923dc7/include/aws/http/proxy.h:310:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_29}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/052d647242f780509d346f7f284300ff03923dc7/include/aws/http/proxy.h:310:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/052d647242f780509d346f7f284300ff03923dc7/include/aws/http/proxy.h:310:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/052d647242f780509d346f7f284300ff03923dc7/include/aws/http/proxy.h:310:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_29, f::Symbol)
+    r = Ref{__JL_Ctag_29}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_29}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/052d647242f780509d346f7f284300ff03923dc7/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_29}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_29, private::Bool = false)
+    (:forwarding_vtable, :tunnelling_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1241,7 +1262,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/052d647242f780509d346f7f284300ff03923dc7/include/aws/http/proxy.h:310:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{__JL_Ctag_29}(x + 32)
     return getfield(x, f)
 end
 
@@ -1254,6 +1275,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_http_proxy_negotiator}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_http_proxy_negotiator, private::Bool = false)
+    (:ref_count, :impl, :strategy_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -2442,14 +2471,15 @@ function aws_http_message_set_body_stream(message, body_stream)
 end
 
 """
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
 """
 mutable struct aws_future_http_message end
 
 """
     aws_future_http_message_new(alloc)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2462,7 +2492,8 @@ end
 """
     aws_future_http_message_set_result_by_move(future, pointer_address)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2475,7 +2506,8 @@ end
 """
     aws_future_http_message_get_result_by_move(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2488,7 +2520,8 @@ end
 """
     aws_future_http_message_peek_result(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2501,7 +2534,8 @@ end
 """
     aws_future_http_message_acquire(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2514,7 +2548,8 @@ end
 """
     aws_future_http_message_release(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2527,7 +2562,8 @@ end
 """
     aws_future_http_message_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2540,7 +2576,8 @@ end
 """
     aws_future_http_message_is_done(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2553,7 +2590,8 @@ end
 """
     aws_future_http_message_get_error(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2566,7 +2604,8 @@ end
 """
     aws_future_http_message_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2579,7 +2618,8 @@ end
 """
     aws_future_http_message_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2592,7 +2632,8 @@ end
 """
     aws_future_http_message_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2605,7 +2646,8 @@ end
 """
     aws_future_http_message_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2618,7 +2660,8 @@ end
 """
     aws_future_http_message_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 # typedef void ( aws_http_on_client_connection_setup_fn ) ( struct aws_http_connection * connection , int error_code , void * user_data )
 """
@@ -869,6 +869,19 @@ function aws_http_library_clean_up()
 end
 
 """
+    aws_http_error_code_is_retryable(error_code)
+
+Documentation not found.
+### Prototype
+```c
+bool aws_http_error_code_is_retryable(int error_code);
+```
+"""
+function aws_http_error_code_is_retryable(error_code)
+    ccall((:aws_http_error_code_is_retryable, libaws_c_http), Bool, (Cint,), error_code)
+end
+
+"""
     aws_http_status_text(status_code)
 
 Returns the description of common status codes. Ex: 404 -> "Not Found" An empty string is returned if the status code is not recognized.
@@ -1204,29 +1217,37 @@ struct aws_http_proxy_negotiator_tunnelling_vtable
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/943e61fe1acbb8c8b700c0a6f63df7c33228de2e/include/aws/http/proxy.h:310:5)
+    __JL_Ctag_29
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/943e61fe1acbb8c8b700c0a6f63df7c33228de2e/include/aws/http/proxy.h:310:5)"
+struct __JL_Ctag_29
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/943e61fe1acbb8c8b700c0a6f63df7c33228de2e/include/aws/http/proxy.h:310:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_29}, f::Symbol)
     f === :forwarding_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_forwarding_vtable}}(x + 0)
     f === :tunnelling_vtable && return Ptr{Ptr{aws_http_proxy_negotiator_tunnelling_vtable}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/943e61fe1acbb8c8b700c0a6f63df7c33228de2e/include/aws/http/proxy.h:310:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/943e61fe1acbb8c8b700c0a6f63df7c33228de2e/include/aws/http/proxy.h:310:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/943e61fe1acbb8c8b700c0a6f63df7c33228de2e/include/aws/http/proxy.h:310:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_29, f::Symbol)
+    r = Ref{__JL_Ctag_29}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_29}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/943e61fe1acbb8c8b700c0a6f63df7c33228de2e/include/aws/http/proxy.h:310:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_29}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_29, private::Bool = false)
+    (:forwarding_vtable, :tunnelling_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1241,7 +1262,7 @@ end
 function Base.getproperty(x::Ptr{aws_http_proxy_negotiator}, f::Symbol)
     f === :ref_count && return Ptr{aws_ref_count}(x + 0)
     f === :impl && return Ptr{Ptr{Cvoid}}(x + 24)
-    f === :strategy_vtable && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/943e61fe1acbb8c8b700c0a6f63df7c33228de2e/include/aws/http/proxy.h:310:5)"}(x + 32)
+    f === :strategy_vtable && return Ptr{__JL_Ctag_29}(x + 32)
     return getfield(x, f)
 end
 
@@ -1254,6 +1275,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_http_proxy_negotiator}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_http_proxy_negotiator, private::Bool = false)
+    (:ref_count, :impl, :strategy_vtable, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -2442,14 +2471,15 @@ function aws_http_message_set_body_stream(message, body_stream)
 end
 
 """
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
 """
 mutable struct aws_future_http_message end
 
 """
     aws_future_http_message_new(alloc)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2462,7 +2492,8 @@ end
 """
     aws_future_http_message_set_result_by_move(future, pointer_address)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2475,7 +2506,8 @@ end
 """
     aws_future_http_message_get_result_by_move(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2488,7 +2520,8 @@ end
 """
     aws_future_http_message_peek_result(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2501,7 +2534,8 @@ end
 """
     aws_future_http_message_acquire(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2514,7 +2548,8 @@ end
 """
     aws_future_http_message_release(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2527,7 +2562,8 @@ end
 """
     aws_future_http_message_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2540,7 +2576,8 @@ end
 """
     aws_future_http_message_is_done(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2553,7 +2590,8 @@ end
 """
     aws_future_http_message_get_error(future)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2566,7 +2604,8 @@ end
 """
     aws_future_http_message_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2579,7 +2618,8 @@ end
 """
     aws_future_http_message_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2592,7 +2632,8 @@ end
 """
     aws_future_http_message_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2605,7 +2646,8 @@ end
 """
     aws_future_http_message_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);
@@ -2618,7 +2660,8 @@ end
 """
     aws_future_http_message_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<aws\\_http\\_message*>
+
 ### Prototype
 ```c
 AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_http_message, struct aws_http_message, AWS_HTTP_API);


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_http_jll** to version **0.10.9**
- Updated **JuliaServices/LibAwsHTTP.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings